### PR TITLE
Stabilize notebook split note Playwright test

### DIFF
--- a/tests/browser/notebook/create.spec.ts
+++ b/tests/browser/notebook/create.spec.ts
@@ -51,8 +51,12 @@ test("split note", async ({ page, notebook }) => {
   await notebook.clickEndOfNote("note1");
 
   // Move left a few times to split in a safer spot
+  // Move left twice, waiting for each movement so the cursor is where we expect.
   await waitForSelectionChange(page, async () => {
     await page.keyboard.press("ArrowLeft");
+  });
+
+  await waitForSelectionChange(page, async () => {
     await page.keyboard.press("ArrowLeft");
   });
 


### PR DESCRIPTION
## Summary
- ensure the split note browser test waits for each left arrow movement before splitting
- reduce selection timing flake by waiting for sequential selection changes

## Testing
- npx playwright test tests/browser/notebook/create.spec.ts --project=chromium --reporter=list

------
https://chatgpt.com/codex/tasks/task_b_68cb1149f0588332a45de470febe048a