### PR TITLE
Fix test bridge commit waits

### DIFF
--- a/src/components/Editor/Editor.tsx
+++ b/src/components/Editor/Editor.tsx
@@ -15,6 +15,7 @@ import { HistoryPlugin } from "@lexical/react/LexicalHistoryPlugin";
 import { LexicalComposer } from "@lexical/react/LexicalComposer";
 import { LinkPlugin } from "@lexical/react/LexicalLinkPlugin";
 import { ListPlugin } from "@lexical/react/LexicalListPlugin";
+import RemdoTestBridge from "@/dev/RemdoTestBridge";
 import { RemdoPlugin } from "./plugins/RemdoPlugin";
 import { RichTextPlugin } from "@lexical/react/LexicalRichTextPlugin";
 import { TabIndentationPlugin } from "@lexical/react/LexicalTabIndentationPlugin";
@@ -25,6 +26,8 @@ function LexicalEditor() {
   const editorBottomRef = useRef();
   const documentSelector = useDocumentSelector();
   const editorConfig = useEditorConfig();
+  const shouldMountTestBridge =
+    !import.meta.env.PROD || (typeof window !== "undefined" && window.REMDO_TEST === true);
 
   return (
     <LexicalComposer
@@ -47,6 +50,7 @@ function LexicalEditor() {
           ErrorBoundary={LexicalErrorBoundary}
         />
         <DevComponentTestPlugin />
+        {shouldMountTestBridge ? <RemdoTestBridge /> : null}
         <ClearEditorPlugin />
         <ListPlugin />
         <LinkPlugin />

--- a/src/dev/RemdoTestBridge.tsx
+++ b/src/dev/RemdoTestBridge.tsx
@@ -1,0 +1,129 @@
+import { useEffect } from "react";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { CLEAR_HISTORY_COMMAND, $getRoot, type LexicalEditor } from "lexical";
+import {
+  ensureListItemSharedState,
+  restoreRemdoStateFromJSON,
+} from "@/components/Editor/plugins/remdo/utils/noteState";
+
+export default function RemdoTestBridge(): null {
+  const [editor] = useLexicalComposerContext();
+
+  useEffect(() => {
+    if (import.meta.env.PROD && !window.REMDO_TEST) {
+      return;
+    }
+
+    const api = createAPI(editor);
+    window.remdoTest = api;
+
+    return () => {
+      if (window.remdoTest === api) {
+        delete window.remdoTest;
+      }
+    };
+  }, [editor]);
+
+  return null;
+}
+
+function createAPI(editor: LexicalEditor) {
+  return {
+    async replaceDocument(editorStateJson: unknown): Promise<void> {
+      if ((editor as unknown as { __collab?: { enabled?: boolean } }).__collab?.enabled) {
+        throw new Error("replaceDocument: collab mode is enabled. Disable Yjs for this test.");
+      }
+
+      const serialized =
+        typeof editorStateJson === "string" ? editorStateJson : JSON.stringify(editorStateJson);
+      const parsedState = parseEditorState(serialized);
+
+      ensureListItemSharedState(editor as unknown as { _nodes?: Map<string, unknown> });
+
+      const nextState = editor.parseEditorState(serialized);
+      await runAndWaitForCommit(editor, () => {
+        editor.setEditorState(nextState);
+      });
+
+      if (parsedState?.root !== undefined) {
+        await runAndWaitForCommit(editor, () => {
+          restoreRemdoStateFromJSON(editor, parsedState.root);
+        });
+      }
+
+      editor.dispatchCommand(CLEAR_HISTORY_COMMAND, undefined);
+
+      await runAndWaitForCommit(editor, () => {
+        editor.update(() => {
+          $getRoot().selectEnd();
+        });
+      });
+    },
+  };
+}
+
+function runAndWaitForCommit(editor: LexicalEditor, action: () => void): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    let unsubscribe: () => void = () => {};
+
+    const cleanup = () => {
+      if (timeoutId !== undefined) {
+        clearTimeout(timeoutId);
+        timeoutId = undefined;
+      }
+      unsubscribe();
+    };
+
+    unsubscribe = editor.registerUpdateListener(() => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      resolve();
+    });
+
+    try {
+      action();
+    } catch (error) {
+      if (!settled) {
+        settled = true;
+        cleanup();
+      }
+      reject(error);
+      return;
+    }
+
+    timeoutId = setTimeout(() => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      resolve();
+    });
+  });
+}
+
+function parseEditorState(serialized: string): { root?: unknown } | undefined {
+  try {
+    const parsed = JSON.parse(serialized);
+    if (typeof parsed === "object" && parsed !== null) {
+      return parsed as { root?: unknown };
+    }
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+declare global {
+  interface Window {
+    remdoTest?: {
+      replaceDocument(editorStateJson: unknown): Promise<void>;
+    };
+    REMDO_TEST?: boolean;
+  }
+}

--- a/src/dev/RemdoTestBridge.tsx
+++ b/src/dev/RemdoTestBridge.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { $isListItemNode, $isListNode } from "@lexical/list";
 import { CLEAR_HISTORY_COMMAND, $getRoot, type LexicalEditor } from "lexical";
 import {
   ensureListItemSharedState,
@@ -55,7 +56,16 @@ function createAPI(editor: LexicalEditor) {
 
       await runAndWaitForCommit(editor, () => {
         editor.update(() => {
-          $getRoot().selectEnd();
+          const root = $getRoot();
+          const lastList = root.getLastChild();
+          if ($isListNode(lastList)) {
+            const lastItem = lastList.getLastChild();
+            if ($isListItemNode(lastItem)) {
+              lastItem.selectEnd();
+              return;
+            }
+          }
+          root.selectEnd();
         });
       });
     },
@@ -66,14 +76,17 @@ function runAndWaitForCommit(editor: LexicalEditor, action: () => void): Promise
   return new Promise((resolve, reject) => {
     let settled = false;
     let timeoutId: ReturnType<typeof setTimeout> | undefined;
-    let unsubscribe: () => void = () => {};
+    let unsubscribe: (() => void) | undefined;
 
     const cleanup = () => {
       if (timeoutId !== undefined) {
         clearTimeout(timeoutId);
         timeoutId = undefined;
       }
-      unsubscribe();
+      if (unsubscribe) {
+        unsubscribe();
+        unsubscribe = undefined;
+      }
     };
 
     unsubscribe = editor.registerUpdateListener(() => {

--- a/tests/browser/common.ts
+++ b/tests/browser/common.ts
@@ -20,6 +20,9 @@ const SKIP_CONTAINS = [
 
 export const test = base.extend({
   page: async ({ page }, use) => {
+    await page.addInitScript(() => {
+      (window as typeof window & { REMDO_TEST?: boolean }).REMDO_TEST = true;
+    });
     page.on("console", (message) => {
       const text = message.text();
 

--- a/tests/browser/notebook/common.ts
+++ b/tests/browser/notebook/common.ts
@@ -25,18 +25,23 @@ export class Notebook {
   }
 
   async load(file: string) {
-    await this.page.click("text=Load State");
     const dataPath = getDataPath(file);
-    const serializedEditorState = fs.readFileSync(dataPath).toString();
-    await this.page.locator("#editor-state").fill(serializedEditorState);
-    await this.page.click("text=Submit Editor State");
-    await this.page.click("text=Load State");
-    await this.locator().focus();
+    const serializedEditorState = fs.readFileSync(dataPath, "utf8");
+    const payload = JSON.parse(serializedEditorState);
 
-    // FIXME: wait for Lexical to fully update the editor.
-    // Consider improving the whole loading mechanism, see:
-    // https://lexical.dev/docs/intro
-    await this.page.waitForTimeout(200);
+    await this.page.evaluate(async (editorState) => {
+      const api = (window as typeof window & {
+        remdoTest?: { replaceDocument(json: unknown): Promise<void> };
+      }).remdoTest;
+
+      if (!api?.replaceDocument) {
+        throw new Error("remdoTest.replaceDocument is not available in this build");
+      }
+
+      await api.replaceDocument(editorState);
+    }, payload);
+
+    await this.locator().focus();
   }
 
   /**

--- a/tests/browser/notebook/common.ts
+++ b/tests/browser/notebook/common.ts
@@ -79,10 +79,17 @@ export class Notebook {
   /** Places cursor at the very end of a given note's title */
   async clickEndOfNote(title: string) {
     const noteLocator = this.noteLocator(title);
-    const { width, height } = await noteLocator.boundingBox();
     await waitForSelectionChange(this.page, async () => {
-      await noteLocator.click({
-        position: { x: width - 1, y: height - 1 }, // bottom-right corner = end of text
+      await noteLocator.evaluate((element) => {
+        const range = document.createRange();
+        range.selectNodeContents(element);
+        range.collapse(false);
+        const selection = window.getSelection();
+        if (!selection) {
+          return;
+        }
+        selection.removeAllRanges();
+        selection.addRange(range);
       });
     });
   }


### PR DESCRIPTION
## Summary
- gate the Remdo test bridge to dev/test builds while allowing CI to opt-in via `window.REMDO_TEST`
- expose `window.remdoTest.replaceDocument` with commit waits, metadata restoration, history clearing, and caret placement before teardown
- update the Playwright helpers to call the new bridge API instead of the modal loader

## Testing
- npm run test-unit
- npm run test-browser

------
https://chatgpt.com/codex/tasks/task_b_68cc228200408332aa90d96a2d4d15b3