### PR TITLE
test: add Notebook clickLeftOf helper

### DIFF
--- a/tests/browser/notebook/breadcrumbs.spec.ts
+++ b/tests/browser/notebook/breadcrumbs.spec.ts
@@ -26,9 +26,7 @@ test("focus on a particular note", async ({ page, notebook }) => {
 
   // Click note12 to focus
   const note12Locator = notebook.noteLocator("note12");
-  const box = await note12Locator.boundingBox();
-  if (!box) throw new Error("note12 bounding box not found");
-  await page.mouse.click(box.x - 1, box.y + box.height / 2);
+  await notebook.clickLeftOf("note12");
 
   await expect(note12Locator).toBeVisible();
 
@@ -65,10 +63,8 @@ test("folding and breadcrumb navigation", async ({ page, notebook }) => {
 
   // Click note1 to focus
   const note1Locator = notebook.noteLocator("note1");
-  const box = await note1Locator.boundingBox();
-  if (!box) throw new Error("note1 bounding box not found");
   await waitForSelectionChange(page, async () => {
-    await page.mouse.click(box.x - 1, box.y + box.height / 2);
+    await notebook.clickLeftOf("note1");
   });
 
   expect(await notebook.getNotes()).toContain("note12");

--- a/tests/browser/notebook/common.ts
+++ b/tests/browser/notebook/common.ts
@@ -110,6 +110,19 @@ export class Notebook {
     }
     return result;
   }
+
+  async clickLeftOf(title: string, minimumMargin = 4) {
+    const locator = this.noteLocator(title);
+    await locator.waitFor({ state: "visible" });
+    const box = await locator.boundingBox();
+    if (!box) {
+      throw new Error(`Bounding box not found for note "${title}"`);
+    }
+    const margin = Math.max(0, minimumMargin);
+    const x = Math.max(0, box.x - margin);
+    const y = box.y + box.height / 2;
+    await this.page.mouse.click(x, y);
+  }
 }
 
 class Menu {


### PR DESCRIPTION
## Summary
- add a reusable Notebook.clickLeftOf helper that safely waits for visibility, reads the bounding box, and clicks with a margin
- update breadcrumbs browser tests to use the helper instead of duplicating bounding-box math

## Testing
- npm run test-unit
- npm run test-browser

------
https://chatgpt.com/codex/tasks/task_b_68cd5097ef44833290818f793d5085a4