### PR TITLE
test: stabilize folded note delete

### DIFF
--- a/tests/browser/notebook/delete.spec.ts
+++ b/tests/browser/notebook/delete.spec.ts
@@ -19,6 +19,8 @@ test("backspace at the beginning of a note after a folded note", async ({ page, 
   await notebook.clickBeginningOfNote("note1");
   await page.keyboard.press("Backspace");
 
+  await expect(page.locator(".note-folded")).toHaveCount(0);
+
   expect(await notebook.html()).toMatchSnapshot("html-after-note1-delete");
 });
 

--- a/tests/browser/notebook/delete.spec.ts
+++ b/tests/browser/notebook/delete.spec.ts
@@ -1,4 +1,4 @@
-import { test } from "./common";
+import { test, waitForSelectionChange } from "./common";
 import { expect } from "@playwright/test";
 
 test("backspace at the beginning of a note", async ({ page, notebook }) => {
@@ -17,9 +17,9 @@ test("backspace at the beginning of a note after a folded note", async ({ page, 
   await menu.fold();
 
   await notebook.clickBeginningOfNote("note1");
-  await page.keyboard.press("Backspace");
-
-  await expect(page.locator(".note-folded")).toHaveCount(0);
+  await waitForSelectionChange(page, async () => {
+    await page.keyboard.press("Backspace");
+  });
 
   expect(await notebook.html()).toMatchSnapshot("html-after-note1-delete");
 });


### PR DESCRIPTION
## Summary
- ensure the folded delete browser test waits for fold state to settle before snapshotting

## Testing
- npm run test-unit
- npm run test-browser

------
https://chatgpt.com/codex/tasks/task_b_68cfc42762448332ab1dd228107bf880