### PR TITLE
Use keyboard interactions in notebook caret helpers

### DIFF
--- a/tests/browser/notebook/common.ts
+++ b/tests/browser/notebook/common.ts
@@ -72,24 +72,20 @@ export class Notebook {
   async clickEndOfNote(title: string) {
     const noteLocator = this.noteLocator(title);
     await waitForSelectionChange(this.page, async () => {
-      await noteLocator.evaluate((element) => {
-        const range = document.createRange();
-        range.selectNodeContents(element);
-        range.collapse(false);
-        const selection = window.getSelection();
-        if (!selection) {
-          return;
-        }
-        selection.removeAllRanges();
-        selection.addRange(range);
-      });
+      await noteLocator.selectText();
+    });
+    await waitForSelectionChange(this.page, async () => {
+      await this.page.keyboard.press("ArrowRight");
     });
   }
 
   async clickBeginningOfNote(title: string) {
     const noteLocator = this.noteLocator(title);
     await waitForSelectionChange(this.page, async () => {
-      await noteLocator.click({ position: { x: 1, y: 1 } });
+      await noteLocator.selectText();
+    });
+    await waitForSelectionChange(this.page, async () => {
+      await this.page.keyboard.press("ArrowLeft");
     });
   }
 


### PR DESCRIPTION
## Summary
- adjust the notebook test helpers to select notes and collapse the caret using keyboard arrows
- remove direct DOM manipulation from the helper so folded-note scenarios stay within test-level interactions

## Testing
- npm run test-unit
- npm run test-browser

------
https://chatgpt.com/codex/tasks/task_b_68d106975bf4833294716b08af5b56cc