### PR TITLE
Limit Playwright report deploys to main and codex branches

### DIFF
--- a/.github/workflows/test-browser-shared.yml
+++ b/.github/workflows/test-browser-shared.yml
@@ -142,7 +142,11 @@ jobs:
         run: exit 1
 
   deploy:
-    if: ${{ always() && needs.test.outputs.publish == 'true' }}
+    if: ${{
+      always() &&
+      needs.test.outputs.publish == 'true' &&
+      (github.ref_name == 'main' || startsWith(github.ref_name, 'codex/'))
+    }}
     needs: test
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/test-browser-shared.yml
+++ b/.github/workflows/test-browser-shared.yml
@@ -142,11 +142,7 @@ jobs:
         run: exit 1
 
   deploy:
-    if: ${{
-      always() &&
-      needs.test.outputs.publish == 'true' &&
-      (github.ref_name == 'main' || startsWith(github.ref_name, 'codex/'))
-    }}
+    if: ${{ always() && needs.test.outputs.publish == 'true' && (github.ref_name == 'main' || startsWith(github.ref_name, 'codex/')) }}
     needs: test
     runs-on: ubuntu-latest
     environment:


### PR DESCRIPTION
## Summary
- restrict the deploy job in the shared Playwright workflow so Pages deploys run only for `main` and `codex/*` branches

## Testing
- npm run test-unit
- npm run test-browser

------
https://chatgpt.com/codex/tasks/task_b_68d4100d08d88332b5a97c5a7fa2381b