### PR TITLE
Align Yjs version with Lexical Playground to fix new-doc warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "uuid": "^13.0.0",
         "y-indexeddb": "^9.0.9",
         "y-websocket": "^3.0.0",
-        "yjs": "^13.6.0"
+        "yjs": "13.6.8"
       },
       "devDependencies": {
         "@antfu/eslint-config": "^5.4.1",
@@ -10927,12 +10927,12 @@
       }
     },
     "node_modules/yjs": {
-      "version": "13.6.27",
-      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.27.tgz",
-      "integrity": "sha512-OIDwaflOaq4wC6YlPBy2L6ceKeKuF7DeTxx+jPzv1FHn9tCZ0ZwSRnUBxD05E3yed46fv/FWJbvR+Ud7x0L7zw==",
+      "version": "13.6.8",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.8.tgz",
+      "integrity": "sha512-ZPq0hpJQb6f59B++Ngg4cKexDJTvfOgeiv0sBc4sUm8CaBWH7OQC4kcCgrqbjJ/B2+6vO49exvTmYfdlPtcjbg==",
       "license": "MIT",
       "dependencies": {
-        "lib0": "^0.2.99"
+        "lib0": "^0.2.74"
       },
       "engines": {
         "node": ">=16.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "uuid": "^13.0.0",
     "y-indexeddb": "^9.0.9",
     "y-websocket": "^3.0.0",
-    "yjs": "^13.6.0"
+    "yjs": "13.6.8"
   },
   "scripts": {
     "lint": "eslint . --ext .ts,.tsx",

--- a/src/features/editor/DocumentSelector/DocumentSelector.tsx
+++ b/src/features/editor/DocumentSelector/DocumentSelector.tsx
@@ -62,10 +62,20 @@ export const DocumentSelectorProvider = ({ children }: { children: ReactNode }) 
         roomPrefix: "notes/0/",
         // Let Lexical's CollaborationPlugin attach listeners before the provider connects,
         // mirroring the working setup used by LexicalDemo.
-        createDoc: () => new Y.Doc({ gc: false }),
-        initializeDoc: (doc, id, isNew) => {
-          if (isNew) {
-            // Ensure the shared root exists before Lexical binds to the document.
+        createDoc: () => {
+          const doc = new Y.Doc({ gc: false });
+          // Mirror Lexical's Playground initialization by creating the shared root
+          // type eagerly before the document is handed to Lexical. This prevents
+          // `syncLexicalUpdateToYjs` from reading a detached Yjs type when the
+          // first editor update runs for a brand-new document.
+          doc.get("root", Y.XmlText);
+          return doc;
+        },
+        initializeDoc: (doc) => {
+          // Persisted docs created before we eagerly instantiated the root may
+          // be missing it. Create the shared type on-demand so old docs behave
+          // like freshly initialized ones.
+          if (!doc.share.has("root")) {
             doc.get("root", Y.XmlText);
           }
         },

--- a/tests/browser/common.ts
+++ b/tests/browser/common.ts
@@ -11,7 +11,6 @@ const SKIP_CONSOLE_MESSAGES = [
   'ArtificialNode__DO_NOT_USE should implement "exportJSON" method to ensure JSON and default HTML serialization works as expected',
   'ArtificialNode__DO_NOT_USE should implement "importJSON" method to ensure JSON and default HTML serialization works as expected',
   'ArtificialNode__DO_NOT_USE must implement static "clone" method',
-  'Invalid access: Add Yjs type to a document before reading data.',
 ];
 
 // Substring matches (partial match)


### PR DESCRIPTION
## Summary
- pin the yjs dependency to 13.6.8 so the collaboration stack matches Lexical Playground's supported range
- eagerly instantiate the shared `root` type for new documents and backfill missing roots when loading existing docs
- drop the custom Yjs patch module so the provider factory relies on upstream behavior

## Testing
- npm run test-unit
- npm run test-browser-collab smoke

------
https://chatgpt.com/codex/tasks/task_b_68d6960927948332ad38eccd10539b48