### PR TITLE
Add #config alias for configuration imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "notes",
   "version": "0.1.0",
   "private": true,
+  "imports": {
+    "#config/*": "./config/*"
+  },
   "dependencies": {
     "@hocuspocus/extension-logger": "^3.2.3",
     "@hocuspocus/provider": "^3.2.3",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,6 @@
 import type { PlaywrightTestConfig } from "@playwright/test";
 import { devices } from "@playwright/test";
-import { env } from "./config/env.server";
+import { env } from "#config/env.server";
 
 const webServer: PlaywrightTestConfig["webServer"] = [
   {

--- a/tests/browser/collab/smoke.spec.ts
+++ b/tests/browser/collab/smoke.spec.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import { expect, Page } from "@playwright/test";
 import { test } from "../common";
 import { Notebook } from "../notebook/common";
-import { env } from "../../../config/env.server";
+import { env } from "#config/env.server";
 
 test.describe("collaboration", () => {
   test.skip(!env.FORCE_WEBSOCKET, "Collaboration smoke tests require FORCE_WEBSOCKET=true");

--- a/tests/browser/notebook/common.ts
+++ b/tests/browser/notebook/common.ts
@@ -3,7 +3,7 @@ import { Page, Locator } from "@playwright/test";
 import fs from "fs";
 import prettier from "prettier";
 import { getDataPath } from "tests/common.js";
-import { env } from "../../../config/env.server";
+import { env } from "#config/env.server";
 
 export class Notebook {
   constructor(private readonly page: Page) { }

--- a/tests/browser/notebook/fold.spec.ts
+++ b/tests/browser/notebook/fold.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from "@playwright/test";
 import { test, waitForSelectionChange } from "./common";
-import { env } from "../../../config/env.server";
+import { env } from "#config/env.server";
 
 test("add new element after a folded one", async ({ page, notebook }) => {
   test.skip(env.FORCE_WEBSOCKET, "Flaky in collab mode"); //FIXME

--- a/tests/unit/collab/provider.spec.ts
+++ b/tests/unit/collab/provider.spec.ts
@@ -4,7 +4,7 @@ import { afterAll, beforeAll, expect, it } from "vitest";
 import { WebsocketProvider } from "y-websocket";
 import * as Y from "yjs";
 import WS from "ws";
-import { env } from "../../../config/env.server";
+import { env } from "#config/env.server";
 
 declare global {
   let __collabProviders: WebsocketProvider[] | undefined;

--- a/tests/unit/common/hooks.tsx
+++ b/tests/unit/common/hooks.tsx
@@ -16,7 +16,7 @@ import {
   ensureListItemSharedState,
   restoreRemdoStateFromJSON,
 } from '@/features/editor/plugins/remdo/utils/noteState';
-import { env } from '../../../config/env.server';
+import { env } from '#config/env.server';
 import { DocumentSelectorType } from '@/features/editor/DocumentSelector/DocumentSelector';
 import { WebsocketProvider } from 'y-websocket';
 import * as Y from 'yjs';

--- a/tests/unit/common/logger.ts
+++ b/tests/unit/common/logger.ts
@@ -2,7 +2,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
-import { env } from '../../../config/env.server';
+import { env } from '#config/env.server';
 const debugEnabled = env.DEBUG.length > 0;
 
 const _info = console.info;

--- a/tests/unit/performance/utils.ts
+++ b/tests/unit/performance/utils.ts
@@ -1,3 +1,4 @@
+import { env } from "#config/env.server";
 import { Note } from "@/features/editor/plugins/remdo/utils/api";
 import { $getRoot } from "lexical";
 
@@ -131,4 +132,3 @@ export function countNotes(lexicalUpdate: (fn: () => void) => void) {
   });
   return count;
 }
-import { env } from "../../../config/env.server";

--- a/tests/unit/serialization.spec.ts
+++ b/tests/unit/serialization.spec.ts
@@ -12,7 +12,7 @@ import { getNotes, lexicalStateKeyCompare } from "./common/utils";
 import { $convertToMarkdownString, TRANSFORMERS } from "@lexical/markdown";
 import fs from "fs";
 import { it } from "vitest";
-import { env } from "../../config/env.server";
+import { env } from "#config/env.server";
 import type { RemdoLexicalEditor } from "@/features/editor/plugins/remdo/ComposerContext";
 import type { Note } from "@/features/editor/plugins/remdo/utils/api";
 import { Note as NoteApi } from "@/features/editor/plugins/remdo/utils/api";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,10 @@
     "jsx": "react-jsx",
 
     "baseUrl": ".",
-    "paths": { "@/*": ["./src/*"] },
+    "paths": {
+      "@/*": ["./src/*"],
+      "#config/*": ["./config/*"]
+    },
 
     "types": ["node", "vite/client"],
     "allowSyntheticDefaultImports": true,

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -4,7 +4,7 @@ import react from "@vitejs/plugin-react";
 import { visualizer } from "rollup-plugin-visualizer";
 import { defineConfig } from "vite";
 import type { PluginOption } from "vite";
-import { env } from "./config/env.server";
+import { env } from "#config/env.server";
 
 export default defineConfig(({ command }) => {
   const enableFastRefresh = command === 'serve' && process.env.VITE_ENABLE_FAST_REFRESH !== 'false';
@@ -42,6 +42,10 @@ export default defineConfig(({ command }) => {
         {
           find: "@",
           replacement: path.resolve("./src"),
+        },
+        {
+          find: "#config",
+          replacement: path.resolve("./config"),
         },
       ],
     },


### PR DESCRIPTION
## Summary
- add a #config package alias for the configuration directory in Node, TypeScript, and Vite resolution
- update unit and browser tests to read env settings via the new alias instead of deep relative paths

## Testing
- npm run test-unit
- npm run test-browser

------
https://chatgpt.com/codex/tasks/task_b_68d782cb45e08332b50c5115522921de