### PR TITLE
Refactor workflows for reusable test logic and collab publishing

### DIFF
--- a/.github/workflows/node-test-shared.yml
+++ b/.github/workflows/node-test-shared.yml
@@ -1,0 +1,57 @@
+name: Node Tests
+
+on:
+  workflow_call:
+    inputs:
+      command:
+        description: Command to execute in the Node environment
+        required: true
+        type: string
+      websocket:
+        description: Start collaboration WebSocket server before running
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm ci --no-audit --no-fund
+
+      - name: Start WebSocket server
+        if: ${{ inputs.websocket }}
+        run: |
+          set -euo pipefail
+          npm run websocket &
+          echo $! > ws-server.pid
+          for _ in {1..20}; do
+            if nc -z localhost 8080; then
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "WebSocket server failed to start" >&2
+          exit 1
+
+      - name: Run command
+        env:
+          FORCE_COLOR: "1"
+        run: ${{ inputs.command }}
+
+      - name: Stop WebSocket server
+        if: ${{ always() && inputs.websocket }}
+        run: |
+          if [ -f ws-server.pid ]; then
+            kill $(cat ws-server.pid) || true
+            rm -f ws-server.pid
+          fi

--- a/.github/workflows/test-browser-collab.yml
+++ b/.github/workflows/test-browser-collab.yml
@@ -5,8 +5,83 @@ on:
   schedule:
     - cron: "13 * * * *"
 
+permissions:
+  actions: read
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
-  call-shared:
+  run:
     uses: ./.github/workflows/test-browser-shared.yml
     with:
-      collab: true
+      command: npm run test-browser-collab
+
+  prepare-pages:
+    if: ${{ always() && needs.run.outputs.report_present == 'true' && (github.ref_name == 'main' || startsWith(github.ref_name, 'codex/')) }}
+    needs: run
+    runs-on: ubuntu-latest
+    env:
+      BRANCH_SLUG: ${{ needs.run.outputs.slug }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Download test artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: data
+          path: data
+
+      - name: Fetch existing GitHub Pages content
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code origin gh-pages &>/dev/null; then
+            git fetch origin gh-pages:gh-pages
+            git worktree add gh-pages-source gh-pages
+          fi
+
+      - name: Prepare Pages artifact
+        run: |
+          set -euo pipefail
+          mkdir -p pages/branches
+          if [ -d gh-pages-source ]; then
+            rsync -a --delete --exclude '.git' gh-pages-source/ pages/
+          fi
+          rm -rf pages/playwright-report
+          rm -rf "pages/branches/${BRANCH_SLUG}"
+          mv data/playwright-report "pages/branches/${BRANCH_SLUG}"
+          cd pages/branches
+          ls -1t | tail -n +21 | xargs -r rm -rf
+          cd ../..
+
+      - name: Upload Playwright report to GitHub Pages
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: pages
+
+  deploy:
+    if: ${{ needs.prepare-pages.result == 'success' }}
+    needs:
+      - run
+      - prepare-pages
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ format('{0}branches/{1}/', steps.deployment.outputs.page_url, needs.run.outputs.slug) }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+      - name: Log report location
+        env:
+          REPORT_URL: ${{ format('{0}branches/{1}/', steps.deployment.outputs.page_url, needs.run.outputs.slug) }}
+          BRANCH_SLUG: ${{ needs.run.outputs.slug }}
+        run: |
+          set -euo pipefail
+          echo "Playwright report for branch '${BRANCH_SLUG}' available at: ${REPORT_URL}"

--- a/.github/workflows/test-browser-shared.yml
+++ b/.github/workflows/test-browser-shared.yml
@@ -3,25 +3,19 @@ name: Playwright Browser Tests
 on:
   workflow_call:
     inputs:
-      collab:
-        description: Run collaboration-specific Playwright suite
-        default: false
-        type: boolean
+      command:
+        description: Command to execute Playwright suite
+        required: true
+        type: string
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
-
-concurrency:
-  group: pages-${{ github.ref }}
-  cancel-in-progress: false
 
 jobs:
   test:
     runs-on: ubuntu-latest
     outputs:
-      publish: ${{ steps.publish.outputs.enabled }}
+      report_present: ${{ steps.report.outputs.present }}
       slug: ${{ steps.branch.outputs.slug }}
     steps:
       - uses: actions/checkout@v5
@@ -37,16 +31,9 @@ jobs:
         run: npx playwright install --with-deps chromium
 
       - name: Run Playwright tests
-        id: run-standard
-        if: ${{ !inputs.collab }}
+        id: run-tests
         continue-on-error: true
-        run: npm run test-browser
-
-      - name: Run collab Playwright tests
-        id: run-collab
-        if: ${{ inputs.collab }}
-        continue-on-error: true
-        run: npm run test-browser-collab
+        run: ${{ inputs.command }}
 
       - uses: actions/upload-artifact@v4
         if: always()
@@ -76,69 +63,6 @@ jobs:
           fi
           echo "slug=$slug" >>"$GITHUB_OUTPUT"
 
-      - name: Determine publishing eligibility
-        id: publish
-        if: always()
-        env:
-          REPORT_PRESENT: ${{ steps.report.outputs.present }}
-        run: |
-          can_publish=false
-          if [ "$REPORT_PRESENT" = "true" ]; then
-            can_publish=true
-          fi
-          echo "enabled=$can_publish" >>"$GITHUB_OUTPUT"
-
-      - name: Fetch existing GitHub Pages content
-        if: ${{ steps.publish.outputs.enabled == 'true' }}
-        run: |
-          set -euo pipefail
-          if git ls-remote --exit-code origin gh-pages &>/dev/null; then
-            git fetch origin gh-pages:gh-pages
-            git worktree add gh-pages-source gh-pages
-          fi
-
-      - name: Prepare Pages artifact
-        if: ${{ steps.publish.outputs.enabled == 'true' }}
-        env:
-          BRANCH_SLUG: ${{ steps.branch.outputs.slug }}
-        run: |
-          set -euo pipefail
-          mkdir -p pages/branches
-          if [ -d gh-pages-source ]; then
-            rsync -a --delete --exclude '.git' gh-pages-source/ pages/
-          fi
-          rm -rf pages/playwright-report
-          rm -rf "pages/branches/${BRANCH_SLUG}"
-          mv data/playwright-report "pages/branches/${BRANCH_SLUG}"
-          cd pages/branches
-          ls -1t | tail -n +21 | xargs -r rm -rf
-          cd ../..
-
-      - name: Upload Playwright report to GitHub Pages
-        if: ${{ steps.publish.outputs.enabled == 'true' }}
-        uses: actions/upload-pages-artifact@v4
-        with:
-          path: pages
-
       - name: Capture Playwright failure
-        if: ${{ steps.run-standard.outcome == 'failure' || steps.run-collab.outcome == 'failure' }}
+        if: ${{ steps.run-tests.outcome == 'failure' }}
         run: exit 1
-
-  deploy:
-    if: ${{ always() && needs.test.outputs.publish == 'true' && (github.ref_name == 'main' || startsWith(github.ref_name, 'codex/')) }}
-    needs: test
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ format('{0}branches/{1}/', steps.deployment.outputs.page_url, needs.test.outputs.slug) }}
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
-      - name: Log report location
-        env:
-          REPORT_URL: ${{ format('{0}branches/{1}/', steps.deployment.outputs.page_url, needs.test.outputs.slug) }}
-          BRANCH_SLUG: ${{ needs.test.outputs.slug }}
-        run: |
-          set -euo pipefail
-          echo "Playwright report for branch '${BRANCH_SLUG}' available at: ${REPORT_URL}"

--- a/.github/workflows/test-browser.yml
+++ b/.github/workflows/test-browser.yml
@@ -5,3 +5,5 @@ on: push
 jobs:
   call-shared:
     uses: ./.github/workflows/test-browser-shared.yml
+    with:
+      command: npm run test-browser

--- a/.github/workflows/test-serialization.yml
+++ b/.github/workflows/test-serialization.yml
@@ -4,17 +4,7 @@ on: push
 
 jobs:
   test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
-        with:
-          node-version: 22
-      - name: Install Dependencies
-        run: |
-          npm ci --no-audit --no-fund
-      - name: Run serialization round-trip test
-        env:
-          VITEST_SERIALIZATION_FILE: tree_complex
-        run: |
-          npm run test-serialization
+    uses: ./.github/workflows/node-test-shared.yml
+    with:
+      command: |
+        VITEST_SERIALIZATION_FILE=tree_complex npm run test-serialization

--- a/.github/workflows/test-unit-collab.yml
+++ b/.github/workflows/test-unit-collab.yml
@@ -4,36 +4,7 @@ on: push
 
 jobs:
   test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
-        with:
-          node-version: 22
-      - name: Install Dependencies
-        run: |
-          npm ci --no-audit --no-fund
-      - name: Start WebSocket server
-        run: |
-          npm run websocket &
-          echo $! > ws-server.pid
-          for _ in {1..20}; do
-            if nc -z localhost 8080; then
-              exit 0
-            fi
-            sleep 1
-          done
-          echo "WebSocket server failed to start" >&2
-          exit 1
-      - name: Run Vitest (Collab)
-        env:
-          FORCE_WEBSOCKET: "true"
-        run: |
-          npm run test-unit-collab
-      - name: Stop WebSocket server
-        if: always()
-        run: |
-          if [ -f ws-server.pid ]; then
-            kill $(cat ws-server.pid) || true
-            rm -f ws-server.pid
-          fi
+    uses: ./.github/workflows/node-test-shared.yml
+    with:
+      command: FORCE_WEBSOCKET=true npm run test-unit-collab
+      websocket: true

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -4,15 +4,6 @@ on: push
 
 jobs:
   test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
-        with:
-          node-version: 22
-      - name: Install Dependencies
-        run: |
-          npm ci --no-audit --no-fund
-      - name: Run Vitest
-        run: |
-          npm run test-unit
+    uses: ./.github/workflows/node-test-shared.yml
+    with:
+      command: npm run test-unit


### PR DESCRIPTION
## Summary
- move GitHub Pages publishing and permissions to the collab Playwright workflow
- add a reusable node-test workflow that deduplicates unit and serialization job steps
- simplify the Playwright reusable workflow by parameterizing the command it runs

## Testing
- npm run test-unit
- npm run test-browser

------
https://chatgpt.com/codex/tasks/task_b_68d90d0b4ba88332a99d30a3a7bd0cb8