### PR TITLE
Restore websocket server for collab Playwright workflow

### DIFF
--- a/.github/workflows/test-browser-collab.yml
+++ b/.github/workflows/test-browser-collab.yml
@@ -20,6 +20,7 @@ jobs:
     uses: ./.github/workflows/test-browser-shared.yml
     with:
       command: npm run test-browser-collab
+      websocket: true
 
   prepare-pages:
     if: ${{ always() && needs.run.outputs.report_present == 'true' && (github.ref_name == 'main' || startsWith(github.ref_name, 'codex/')) }}

--- a/.github/workflows/test-browser-shared.yml
+++ b/.github/workflows/test-browser-shared.yml
@@ -7,6 +7,10 @@ on:
         description: Command to execute Playwright suite
         required: true
         type: string
+      websocket:
+        description: Start the collab websocket server before running tests
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -29,6 +33,14 @@ jobs:
 
       - name: Install Playwright (Chromium)
         run: npx playwright install --with-deps chromium
+
+      - name: Start websocket server
+        if: ${{ inputs.websocket }}
+        run: |
+          set -euo pipefail
+          npm run websocket &
+          echo "WEBSOCKET_PID=$!" >>"$GITHUB_ENV"
+          npx wait-on --timeout 1000 tcp:127.0.0.1:8080
 
       - name: Run Playwright tests
         id: run-tests
@@ -66,3 +78,12 @@ jobs:
       - name: Capture Playwright failure
         if: ${{ steps.run-tests.outcome == 'failure' }}
         run: exit 1
+
+      - name: Stop websocket server
+        if: ${{ always() && inputs.websocket }}
+        run: |
+          set -euo pipefail
+          if [ -n "${WEBSOCKET_PID:-}" ] && kill -0 "$WEBSOCKET_PID" 2>/dev/null; then
+            kill "$WEBSOCKET_PID"
+            wait "$WEBSOCKET_PID" || true
+          fi


### PR DESCRIPTION
## Summary
- add an optional websocket flag to the shared Playwright workflow so collaboration suites can launch their backend
- enable the websocket helper from the collab workflow to restore the background server GitHub Actions lost after the refactor

## Testing
- npm run test-unit
- npm run test-browser

------
https://chatgpt.com/codex/tasks/task_b_68d9339cf6848332880b3da59483c151