### PR TITLE
Add document selector readiness helper

### DIFF
--- a/src/features/editor/DocumentSelector/DocumentSelector.tsx
+++ b/src/features/editor/DocumentSelector/DocumentSelector.tsx
@@ -32,6 +32,7 @@ export interface DocumentSelectorType {
   yjsProvider: DocumentProvider | null;
   getYjsProvider: () => DocumentProvider | null;
   resetDocument: () => void;
+  ready: () => Promise<void>;
   version: number;
 }
 
@@ -54,6 +55,26 @@ export const DocumentSelectorProvider = ({ children }: { children: ReactNode }) 
   const yjsProviderRef = useRef<DocumentProvider | null>(null);
   const [currentProvider, setCurrentProvider] = useState<DocumentProvider | null>(null);
   const [version, setVersion] = useState(0);
+  const readyStateRef = useRef<{
+    documentID: string;
+    deferred: { promise: Promise<void>; resolve: () => void };
+  } | null>(null);
+
+  const ensureReadyState = useCallback((id: string) => {
+    const current = readyStateRef.current;
+    if (current?.documentID === id) {
+      return current.deferred;
+    }
+
+    let resolve!: () => void;
+    const promise = new Promise<void>((res) => {
+      resolve = res;
+    });
+
+    const deferred = { promise, resolve };
+    readyStateRef.current = { documentID: id, deferred };
+    return deferred;
+  }, []);
 
   const baseProviderFactory = useMemo(
     () =>
@@ -93,13 +114,42 @@ export const DocumentSelectorProvider = ({ children }: { children: ReactNode }) 
     (id: string, yjsDocMap: Map<string, Y.Doc>) => {
       const provider = baseProviderFactory(id, yjsDocMap) as DocumentProvider;
       const doc = yjsDocMap.get(id);
+      ensureReadyState(id);
 
       if (doc) {
+        if (!doc.share.has("root")) {
+          doc.get("root", Y.XmlText);
+        }
         yjsDocs.current.set(id, doc);
       }
 
       yjsProviderRef.current = provider;
       setCurrentProvider(provider);
+
+      const resolveReady = () => {
+        const current = readyStateRef.current;
+        if (current?.documentID !== id) {
+          return;
+        }
+
+        const readyDoc = yjsDocs.current.get(id);
+        if (!readyDoc) {
+          return;
+        }
+
+        if (!readyDoc.share.has("root")) {
+          readyDoc.get("root", Y.XmlText);
+        }
+
+        current.deferred.resolve();
+      };
+
+      const handleSync = (isSynced: boolean) => {
+        if (!isSynced) {
+          return;
+        }
+        resolveReady();
+      };
 
       const handleDestroy = () => {
         if (doc && yjsDocs.current.get(id) === doc) {
@@ -109,29 +159,56 @@ export const DocumentSelectorProvider = ({ children }: { children: ReactNode }) 
           yjsProviderRef.current = null;
         }
         setCurrentProvider((prev) => (prev === provider ? null : prev));
+        if (readyStateRef.current?.documentID === id) {
+          readyStateRef.current = null;
+        }
+        // @ts-expect-error The Y-Websocket provider emits a "sync" event even though it's not part of
+        // the typed event map.
+        provider.off("sync", handleSync);
         // @ts-expect-error The Y-Websocket provider emits a "destroy" event even though it's
         // not part of the typed event map.
         provider.off("destroy", handleDestroy);
       };
 
+      // @ts-expect-error The Y-Websocket provider emits a "sync" event even though it's not part of
+      // the typed event map.
+      provider.on("sync", handleSync);
       // @ts-expect-error The Y-Websocket provider emits a "destroy" event even though it's not
       // part of the typed event map.
       provider.on("destroy", handleDestroy);
 
+      if (provider.synced) {
+        resolveReady();
+      }
+
       return provider;
     },
-    [baseProviderFactory],
+    [baseProviderFactory, ensureReadyState],
   );
 
   const resetDocument = useCallback(() => {
+    const pendingReady = readyStateRef.current;
     const provider = yjsProviderRef.current;
     if (provider) {
       provider.destroy();
     } else {
       yjsDocs.current.delete(documentID);
     }
+    if (pendingReady?.documentID === documentID) {
+      pendingReady.deferred.resolve();
+    }
+    if (readyStateRef.current?.documentID === documentID) {
+      readyStateRef.current = null;
+    }
     setVersion((prev) => prev + 1);
   }, [documentID]);
+
+  const ready = useCallback(() => {
+    if (editorConfig.disableWS) {
+      return Promise.resolve();
+    }
+    return ensureReadyState(documentID).promise;
+  }, [documentID, editorConfig.disableWS, ensureReadyState]);
 
   const contextValue = useMemo(
     () => ({
@@ -142,11 +219,13 @@ export const DocumentSelectorProvider = ({ children }: { children: ReactNode }) 
       yjsProvider: currentProvider,
       getYjsProvider,
       resetDocument,
+      ready,
       version,
     }),
     [
       currentProvider,
       documentID,
+      ready,
       getYjsDoc,
       getYjsProvider,
       resetDocument,
@@ -160,6 +239,7 @@ export const DocumentSelectorProvider = ({ children }: { children: ReactNode }) 
       return;
     }
 
+    const pendingReady = readyStateRef.current;
     const provider = yjsProviderRef.current;
     if (provider) {
       provider.destroy();
@@ -167,6 +247,10 @@ export const DocumentSelectorProvider = ({ children }: { children: ReactNode }) 
 
     yjsDocs.current.clear();
     yjsProviderRef.current = null;
+    if (pendingReady) {
+      pendingReady.deferred.resolve();
+    }
+    readyStateRef.current = null;
   }, [editorConfig.disableWS]);
 
   return <DocumentSelectorContext value={contextValue}>{children}</DocumentSelectorContext>;

--- a/tests/unit/collab/document_selector.spec.ts
+++ b/tests/unit/collab/document_selector.spec.ts
@@ -15,21 +15,7 @@ async function switchDocument(context: TestContext, id: string) {
 
   await waitFor(() => context.documentSelector.documentID === id);
   await waitFor(() => context.editor !== previousEditor);
-  await waitFor(() => context.documentSelector.getYjsProvider() !== null);
-  await waitFor(
-    () => context.documentSelector.getYjsProvider()?.synced === true,
-    { timeout: 5000 },
-  );
-  await waitFor(() => {
-    const doc = context.documentSelector.getYjsDoc();
-    if (!doc) {
-      return false;
-    }
-    if (!doc.share.has("root")) {
-      doc.get("root", Y.XmlText);
-    }
-    return true;
-  });
+  await context.documentSelector.ready();
 }
 
 const shouldRun = env.FORCE_WEBSOCKET;
@@ -44,6 +30,7 @@ it.runIf(shouldRun)("preserves independent state for each document", async (cont
     mainNote.createChild("main child 1");
   });
 
+  await context.documentSelector.ready();
   await waitFor(
     () => {
       const doc = context.documentSelector.getYjsDoc();
@@ -67,6 +54,7 @@ it.runIf(shouldRun)("preserves independent state for each document", async (cont
     flatNote1.text = "flat note1 updated";
   });
 
+  await context.documentSelector.ready();
   await waitFor(
     () => {
       const doc = context.documentSelector.getYjsDoc();
@@ -85,6 +73,7 @@ it.runIf(shouldRun)("preserves independent state for each document", async (cont
 
   await switchDocument(context, "main");
 
+  await context.documentSelector.ready();
   await waitFor(() => {
     const doc = context.documentSelector.getYjsDoc();
     if (!doc) {
@@ -100,6 +89,7 @@ it.runIf(shouldRun)("preserves independent state for each document", async (cont
 
   await switchDocument(context, "flat");
 
+  await context.documentSelector.ready();
   await waitFor(() => {
     const doc = context.documentSelector.getYjsDoc();
     if (!doc) {


### PR DESCRIPTION
## Summary
- add a ready() helper to the document selector that resolves after the provider syncs and the Yjs doc root exists
- resolve pending readiness promises when collaboration is disabled or a document reset is requested
- update the document selector unit tests to rely on the new helper instead of polling for provider state

## Testing
- npm run test-unit
- npm run test-browser

------
https://chatgpt.com/codex/tasks/task_b_68da8c2aa1708332ad3dfd8bf2520a5d