### PR TITLE
Split DocumentSelector into provider and menu components

### DIFF
--- a/src/features/editor/DocumentSelector/DocumentMenu.tsx
+++ b/src/features/editor/DocumentSelector/DocumentMenu.tsx
@@ -1,0 +1,29 @@
+import { Dropdown, NavDropdown } from "react-bootstrap";
+import { useNavigate } from "react-router-dom";
+import { NotesState } from "../plugins/remdo/utils/api";
+import { useDocumentSelector } from "./DocumentSessionProvider";
+
+export function DocumentMenu() {
+  const { setDocumentID } = useDocumentSelector();
+  const navigate = useNavigate();
+
+  return (
+    <div data-testid="document-selector">
+      <NavDropdown title="Documents">
+        {NotesState.documents().map((document) => (
+          <Dropdown.Item
+            href={`?documentID=${document}`}
+            key={document}
+            onClick={(e) => {
+              e.preventDefault();
+              navigate("/");
+              setDocumentID(document);
+            }}
+          >
+            {document}
+          </Dropdown.Item>
+        ))}
+      </NavDropdown>
+    </div>
+  );
+}

--- a/src/features/editor/DocumentSelector/DocumentSessionProvider.tsx
+++ b/src/features/editor/DocumentSelector/DocumentSessionProvider.tsx
@@ -10,10 +10,8 @@ import {
   useRef,
   useState,
 } from "react";
-import { Dropdown, NavDropdown } from "react-bootstrap";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router-dom";
 import { useEditorConfig } from "../config";
-import { NotesState } from "../plugins/remdo/utils/api";
 import * as Y from "yjs";
 import {
   createCollaborationProviderFactory,
@@ -171,28 +169,3 @@ export const DocumentSelectorProvider = ({ children }: { children: ReactNode }) 
 
   return <DocumentSelectorContext value={contextValue}>{children}</DocumentSelectorContext>;
 };
-
-export function DocumentSelector() {
-  const { setDocumentID } = useDocumentSelector();
-  const navigate = useNavigate();
-
-  return (
-    <div data-testid="document-selector">
-      <NavDropdown title="Documents">
-        {NotesState.documents().map((document) => (
-          <Dropdown.Item
-            href={`?documentID=${document}`}
-            key={document}
-            onClick={(e) => {
-              e.preventDefault();
-              navigate("/");
-              setDocumentID(document);
-            }}
-          >
-            {document}
-          </Dropdown.Item>
-        ))}
-      </NavDropdown>
-    </div>
-  );
-}

--- a/src/features/editor/Editor.tsx
+++ b/src/features/editor/Editor.tsx
@@ -1,7 +1,7 @@
 import {
   DocumentSelectorProvider,
   useDocumentSelector,
-} from "./DocumentSelector/DocumentSelector";
+} from "./DocumentSelector/DocumentSessionProvider";
 import "./Editor.scss";
 import { ClickableLinkPlugin as LexicalClickableLinkPlugin } from "@lexical/react/LexicalClickableLinkPlugin";
 import { LexicalErrorBoundary } from "@lexical/react/LexicalErrorBoundary";

--- a/src/features/editor/devtools/DevToolbarPlugin.tsx
+++ b/src/features/editor/devtools/DevToolbarPlugin.tsx
@@ -4,7 +4,7 @@ import { useRemdoLexicalComposerContext } from "../plugins/remdo/ComposerContext
 import { SPACER_COMMAND } from "../plugins/remdo/utils/commands";
 import { YjsDebug } from "./YjsDebug";
 import { useDebug } from "@/DebugContext";
-import { useDocumentSelector } from "../DocumentSelector/DocumentSelector";
+import { useDocumentSelector } from "../DocumentSelector/DocumentSessionProvider";
 import { mergeRegister } from "@lexical/utils";
 import { CONNECTED_COMMAND, TOGGLE_CONNECT_COMMAND } from "@lexical/yjs";
 import {

--- a/src/features/editor/devtools/YjsDebug.tsx
+++ b/src/features/editor/devtools/YjsDebug.tsx
@@ -1,4 +1,4 @@
-import { useDocumentSelector } from "../DocumentSelector/DocumentSelector";
+import { useDocumentSelector } from "../DocumentSelector/DocumentSessionProvider";
 import { useSearchParams } from "react-router-dom";
 
 export function YjsDebug() {

--- a/src/features/editor/plugins/dev/DevComponentTestPlugin.tsx
+++ b/src/features/editor/plugins/dev/DevComponentTestPlugin.tsx
@@ -1,7 +1,7 @@
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import { createContext, use, useEffect } from "react";
 import type { LexicalEditor } from "lexical";
-import { useDocumentSelector } from "../../DocumentSelector/DocumentSelector";
+import { useDocumentSelector } from "../../DocumentSelector/DocumentSessionProvider";
 
 // TODO: To satisfy `react-refresh/only-export-components`, split this context into
 // a standalone module once the dev tooling is ready to consume the new import.

--- a/src/features/editor/plugins/remdo/BreadcrumbsPlugin.tsx
+++ b/src/features/editor/plugins/remdo/BreadcrumbsPlugin.tsx
@@ -3,7 +3,7 @@ import { Note } from "./utils/api";
 import { useCallback, useEffect, useState } from "react";
 import Breadcrumb from "react-bootstrap/Breadcrumb";
 import { Link, useParams } from "react-router-dom";
-import { DocumentSelector } from "@/features/editor/DocumentSelector/DocumentSelector";
+import { DocumentMenu } from "@/features/editor/DocumentSelector/DocumentMenu";
 import { YJS_SYNCED_COMMAND } from "./utils/commands";
 import { COMMAND_PRIORITY_LOW } from "lexical";
 
@@ -88,7 +88,7 @@ export function BreadcrumbPlugin({ documentID }: { documentID: string }) {
     <div>
       <Breadcrumb id="notes-path">
         <Breadcrumb.Item linkAs="div">
-          <DocumentSelector />
+          <DocumentMenu />
         </Breadcrumb.Item>
         <Breadcrumb.Item linkAs={Link} linkProps={{ to: "/" }}>
           {documentID}

--- a/src/features/editor/plugins/remdo/RootSchemaPlugin.tsx
+++ b/src/features/editor/plugins/remdo/RootSchemaPlugin.tsx
@@ -9,7 +9,7 @@ import {
 
 import { useRemdoLexicalComposerContext } from "@/features/editor/plugins/remdo/ComposerContext";
 import { useDisableCollaboration } from "@/features/editor/config";
-import { useDocumentSelector } from "@/features/editor/DocumentSelector/DocumentSelector";
+import { useDocumentSelector } from "@/features/editor/DocumentSelector/DocumentSessionProvider";
 import { mergeLists } from "./utils/unexported";
 
 function $ensureSingleListRoot(rootNode: RootNode): void {

--- a/src/features/editor/plugins/remdo/YjsPlugin.tsx
+++ b/src/features/editor/plugins/remdo/YjsPlugin.tsx
@@ -3,7 +3,7 @@
 import { useEffect } from "react";
 import { useRemdoLexicalComposerContext } from "./ComposerContext";
 import { YJS_SYNCED_COMMAND } from "./utils/commands";
-import { useDocumentSelector } from "../../DocumentSelector/DocumentSelector";
+import { useDocumentSelector } from "../../DocumentSelector/DocumentSessionProvider";
 
 export function YjsPlugin() {
   const [editor] = useRemdoLexicalComposerContext();

--- a/tests/unit/common/hooks.tsx
+++ b/tests/unit/common/hooks.tsx
@@ -17,7 +17,7 @@ import {
   restoreRemdoStateFromJSON,
 } from '@/features/editor/plugins/remdo/utils/noteState';
 import { env } from '#env';
-import { DocumentSelectorType } from '@/features/editor/DocumentSelector/DocumentSelector';
+import { DocumentSelectorType } from '@/features/editor/DocumentSelector/DocumentSessionProvider';
 import { WebsocketProvider } from 'y-websocket';
 import * as Y from 'yjs';
 

--- a/tests/unit/common/test_context.ts
+++ b/tests/unit/common/test_context.ts
@@ -9,7 +9,7 @@ import {
 import { expect } from 'vitest';
 import { RemdoLexicalEditor } from '@/features/editor/plugins/remdo/ComposerContext';
 import { Note } from '@/features/editor/plugins/remdo/utils/api';
-import { DocumentSelectorType } from '@/features/editor/DocumentSelector/DocumentSelector';
+import { DocumentSelectorType } from '@/features/editor/DocumentSelector/DocumentSessionProvider';
 
 export type Queries = BoundFunctions<
   typeof queries & { getAllNotNestedIListItems: typeof getAllByRole.bind }


### PR DESCRIPTION
## Summary
- extract the document session context and provider into DocumentSessionProvider.tsx
- move the document dropdown UI into a standalone DocumentMenu component and update all imports

## Testing
- npm run test-unit
- npm run test-browser
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_b_68dba0630e8c83329ab4fe12bb686ea2