### PR TITLE
Centralize Yjs synced handling in provider

### DIFF
--- a/src/features/editor/DocumentSelector/DocumentSessionProvider.tsx
+++ b/src/features/editor/DocumentSelector/DocumentSessionProvider.tsx
@@ -7,6 +7,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useReducer,
   useRef,
   useState,
 } from "react";
@@ -18,7 +19,17 @@ import {
   getCollaborationEndpoint,
 } from "../collab/createCollaborationProviderFactory";
 
-export type DocumentProvider = Provider & WebsocketProvider;
+type YWebsocketEvents = {
+  synced: (synced: boolean) => void;
+  destroy: () => void;
+};
+
+type TypedProvider = WebsocketProvider & {
+  on<K extends keyof YWebsocketEvents>(event: K, callback: YWebsocketEvents[K]): void;
+  off<K extends keyof YWebsocketEvents>(event: K, callback: YWebsocketEvents[K]): void;
+};
+
+export type DocumentProvider = Provider & TypedProvider;
 
 type ProviderFactory = (id: string, yjsDocMap: Map<string, Y.Doc>) => Provider;
 
@@ -31,6 +42,7 @@ export interface DocumentSelectorType {
   getYjsProvider: () => DocumentProvider | null;
   resetDocument: () => void;
   version: number;
+  synced: boolean;
 }
 
 const DocumentSelectorContext = createContext<DocumentSelectorType | null>(null);
@@ -52,6 +64,7 @@ export const DocumentSelectorProvider = ({ children }: { children: ReactNode }) 
   const yjsProviderRef = useRef<DocumentProvider | null>(null);
   const [currentProvider, setCurrentProvider] = useState<DocumentProvider | null>(null);
   const [version, setVersion] = useState(0);
+  const [synced, updateSynced] = useReducer((_: boolean, value: boolean) => Boolean(value), false);
 
   const baseProviderFactory = useMemo(
     () =>
@@ -107,13 +120,9 @@ export const DocumentSelectorProvider = ({ children }: { children: ReactNode }) 
           yjsProviderRef.current = null;
         }
         setCurrentProvider((prev) => (prev === provider ? null : prev));
-        // @ts-expect-error The Y-Websocket provider emits a "destroy" event even though it's
-        // not part of the typed event map.
         provider.off("destroy", handleDestroy);
       };
 
-      // @ts-expect-error The Y-Websocket provider emits a "destroy" event even though it's not
-      // part of the typed event map.
       provider.on("destroy", handleDestroy);
 
       return provider;
@@ -141,6 +150,7 @@ export const DocumentSelectorProvider = ({ children }: { children: ReactNode }) 
       getYjsProvider,
       resetDocument,
       version,
+      synced,
     }),
     [
       currentProvider,
@@ -148,10 +158,28 @@ export const DocumentSelectorProvider = ({ children }: { children: ReactNode }) 
       getYjsDoc,
       getYjsProvider,
       resetDocument,
+      synced,
       version,
       yjsProviderFactory,
     ],
   );
+
+  useEffect(() => {
+    const handleSynced = (value: boolean) => {
+      updateSynced(Boolean(value));
+    };
+
+    if (!currentProvider) {
+      handleSynced(false);
+      return;
+    }
+
+    handleSynced(currentProvider.synced);
+    currentProvider.on("synced", handleSynced);
+    return () => {
+      currentProvider.off("synced", handleSynced);
+    };
+  }, [currentProvider]);
 
   useEffect(() => {
     if (!editorConfig.disableWS) {

--- a/src/features/editor/plugins/remdo/RootSchemaPlugin.tsx
+++ b/src/features/editor/plugins/remdo/RootSchemaPlugin.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { RootNode } from "lexical";
 import {
   $createListItemNode,
@@ -64,46 +64,10 @@ export function RootSchemaPlugin(): null {
   const [editor] = useRemdoLexicalComposerContext();
   //FIXME review and simplify once collab is refactored
   const disableCollaboration = useDisableCollaboration();
-  const { yjsProvider } = useDocumentSelector();
+  const { synced } = useDocumentSelector();
   const serializationFile = import.meta.env.VITEST_SERIALIZATION_FILE;
   const disableForSerialization = Boolean(serializationFile);
-  // FIXME(remdo): Re-enable the root transform during serialization runs once the snapshot
-  // pipeline no longer relies on the pre-transform document shape.
-  const [hasSynced, setHasSynced] = useState(
-    () =>
-      disableForSerialization ||
-      disableCollaboration ||
-      Boolean(yjsProvider?.synced)
-  );
-
-  useEffect(() => {
-    if (disableForSerialization) {
-      setHasSynced(true);
-      return;
-    }
-    setHasSynced(disableCollaboration || Boolean(yjsProvider?.synced));
-  }, [disableCollaboration, disableForSerialization, yjsProvider]);
-
-  useEffect(() => {
-    if (disableForSerialization || disableCollaboration || !yjsProvider) {
-      return;
-    }
-
-    const handleSynced = (synced: boolean) => {
-      setHasSynced(synced);
-    };
-
-    // y-websocket emits a "synced" event that toggles between true/false as the
-    // provider handshake completes or disconnects. It's missing from the type
-    // definitions.
-    // @ts-expect-error The "synced" event is not declared in the typings.
-    yjsProvider.on("synced", handleSynced);
-
-    return () => {
-      // @ts-expect-error The "synced" event is not declared in the typings.
-      yjsProvider.off("synced", handleSynced);
-    };
-  }, [disableCollaboration, disableForSerialization, yjsProvider]);
+  const hasSynced = disableForSerialization || disableCollaboration || synced;
 
   useEffect(() => {
     if (disableForSerialization) {

--- a/src/features/editor/plugins/remdo/YjsPlugin.tsx
+++ b/src/features/editor/plugins/remdo/YjsPlugin.tsx
@@ -1,27 +1,21 @@
 // @ts-nocheck
 // TODO(remdo): Restore YjsPlugin typing once collaboration wiring migrates to the new provider abstraction.
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useRemdoLexicalComposerContext } from "./ComposerContext";
 import { YJS_SYNCED_COMMAND } from "./utils/commands";
 import { useDocumentSelector } from "../../DocumentSelector/DocumentSessionProvider";
 
 export function YjsPlugin() {
   const [editor] = useRemdoLexicalComposerContext();
-  const documentSelector = useDocumentSelector();
-  const provider = documentSelector.yjsProvider;
+  const { synced } = useDocumentSelector();
+  const previousSynced = useRef(false);
 
   useEffect(() => {
-    if (!provider) {
-      return;
-    }
-    const handleSynced = () => {
+    if (!previousSynced.current && synced) {
       editor.dispatchCommand(YJS_SYNCED_COMMAND, undefined);
-    };
-    provider.on("synced", handleSynced);
-    return () => {
-      provider.off("synced", handleSynced);
-    };
-  }, [provider, editor]);
+    }
+    previousSynced.current = synced;
+  }, [editor, synced]);
 
   return null;
 }


### PR DESCRIPTION
## Summary
- track the Yjs provider sync status inside `DocumentSessionProvider` and expose it via context
- adjust `YjsPlugin` and `RootSchemaPlugin` to consume the shared `synced` flag instead of wiring provider events directly

## Testing
- npm run lint
- npm run typecheck
- npm run test-unit
- npm run test-browser

------
https://chatgpt.com/codex/tasks/task_b_68dba3a0ce808332bb907b69742f302e