### PR TITLE
Refactor document selection navigation

### DIFF
--- a/src/features/editor/DocumentSelector/DocumentMenu.tsx
+++ b/src/features/editor/DocumentSelector/DocumentMenu.tsx
@@ -1,23 +1,19 @@
 import { Dropdown, NavDropdown } from "react-bootstrap";
-import { useNavigate } from "react-router-dom";
 import { NotesState } from "../plugins/remdo/utils/api";
 import { useDocumentSelector } from "./DocumentSessionProvider";
 
 export function DocumentMenu() {
-  const { setDocumentID } = useDocumentSelector();
-  const navigate = useNavigate();
+  const { documentID, selectDocument } = useDocumentSelector();
 
   return (
     <div data-testid="document-selector">
       <NavDropdown title="Documents">
         {NotesState.documents().map((document) => (
           <Dropdown.Item
-            href={`?documentID=${document}`}
             key={document}
-            onClick={(e) => {
-              e.preventDefault();
-              navigate("/");
-              setDocumentID(document);
+            active={document === documentID}
+            onClick={() => {
+              selectDocument(document);
             }}
           >
             {document}

--- a/src/features/editor/DocumentSelector/DocumentSessionProvider.tsx
+++ b/src/features/editor/DocumentSelector/DocumentSessionProvider.tsx
@@ -10,7 +10,7 @@ import {
   useRef,
   useState,
 } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { useEditorConfig } from "../config";
 import * as Y from "yjs";
 import {
@@ -34,6 +34,9 @@ type ProviderFactory = (id: string, yjsDocMap: Map<string, Y.Doc>) => Provider;
 
 export interface DocumentSelectorType {
   documentID: string;
+  selectDocument: (id: string, opts?: { replace?: boolean; path?: string }) => void;
+  setDocumentIdSilently: (id: string) => void;
+  /** @deprecated Use selectDocument or setDocumentIdSilently */
   setDocumentID: (id: string) => void;
   yjsProviderFactory: ProviderFactory;
   getYjsDoc: () => Y.Doc | null;
@@ -56,14 +59,83 @@ export const useDocumentSelector = () => {
 };
 
 export const DocumentSelectorProvider = ({ children }: { children: ReactNode }) => {
-  const [searchParams] = useSearchParams();
-  const [documentID, setDocumentID] = useState(searchParams.get("documentID") ?? "main");
+  type SetURLSearchParams = ReturnType<typeof useSearchParams>[1];
+
+  let searchParamsTuple: [URLSearchParams, SetURLSearchParams] | null = null;
+  try {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    searchParamsTuple = useSearchParams();
+  } catch {
+    searchParamsTuple = null;
+  }
+
+  const hasSearchParams = searchParamsTuple !== null;
+  const [searchParams, setSearchParams] =
+    searchParamsTuple ??
+    [new URLSearchParams(), (() => {}) as SetURLSearchParams];
+
+  let navigateFn: ReturnType<typeof useNavigate>;
+  let hasNavigate = true;
+  try {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    navigateFn = useNavigate();
+  } catch {
+    hasNavigate = false;
+    navigateFn = ((() => undefined) as unknown) as ReturnType<typeof useNavigate>;
+  }
+
+  const [documentID, setDocumentIDState] = useState(
+    () => searchParams.get("documentID") ?? "main",
+  );
   const editorConfig = useEditorConfig();
   const yjsDocs = useRef(new Map<string, Y.Doc>());
   const yjsProviderRef = useRef<DocumentProvider | null>(null);
   const [currentProvider, setCurrentProvider] = useState<DocumentProvider | null>(null);
   const [version, setVersion] = useState(0);
   const [synced, setSynced] = useState(false);
+  const lastSearchParamIdRef = useRef<string | null>(searchParams.get("documentID"));
+
+  const setDocumentIdSilently = useCallback((id: string) => {
+    // eslint-disable-next-line react-hooks-extra/no-direct-set-state-in-use-effect
+    setDocumentIDState((prev) => (prev === id ? prev : id));
+  }, []);
+
+  const selectDocument = useCallback(
+    (id: string, opts?: { replace?: boolean; path?: string }) => {
+      if (documentID === id) {
+        return;
+      }
+
+      setDocumentIdSilently(id);
+
+      if (hasSearchParams) {
+        const nextParams = new URLSearchParams(searchParams);
+        nextParams.set("documentID", id);
+        setSearchParams(nextParams, opts?.replace ? { replace: true } : undefined);
+      }
+
+      if (hasNavigate) {
+        const path = opts?.path ?? "/";
+        navigateFn(path, opts?.replace ? { replace: true } : undefined);
+      }
+    },
+    [
+      documentID,
+      hasNavigate,
+      hasSearchParams,
+      navigateFn,
+      searchParams,
+      setDocumentIdSilently,
+      setSearchParams,
+    ],
+  );
+
+  const setDocumentID = useCallback(
+    (id: string) => {
+      selectDocument(id, { replace: true });
+    },
+    [selectDocument],
+  );
 
   const baseProviderFactory = useMemo(
     () =>
@@ -142,6 +214,8 @@ export const DocumentSelectorProvider = ({ children }: { children: ReactNode }) 
   const contextValue = useMemo(
     () => ({
       documentID,
+      selectDocument,
+      setDocumentIdSilently,
       setDocumentID,
       yjsProviderFactory,
       getYjsDoc,
@@ -157,11 +231,29 @@ export const DocumentSelectorProvider = ({ children }: { children: ReactNode }) 
       getYjsDoc,
       getYjsProvider,
       resetDocument,
+      selectDocument,
+      setDocumentID,
+      setDocumentIdSilently,
       synced,
       version,
       yjsProviderFactory,
     ],
   );
+
+  useEffect(() => {
+    if (!hasSearchParams) {
+      return;
+    }
+
+    const nextSearchParamId = searchParams.get("documentID");
+    if (lastSearchParamIdRef.current === nextSearchParamId) {
+      return;
+    }
+
+    lastSearchParamIdRef.current = nextSearchParamId;
+    const normalizedId = nextSearchParamId ?? "main";
+    setDocumentIdSilently(normalizedId);
+  }, [hasSearchParams, searchParams, setDocumentIdSilently]);
 
   useEffect(() => {
     if (!currentProvider) {

--- a/src/features/editor/DocumentSelector/DocumentSessionProvider.tsx
+++ b/src/features/editor/DocumentSelector/DocumentSessionProvider.tsx
@@ -49,6 +49,12 @@ export interface DocumentSelectorType {
 
 const DocumentSelectorContext = createContext<DocumentSelectorType | null>(null);
 
+function makeSearchWithDoc(id: string, current: URLSearchParams) {
+  const next = new URLSearchParams(current);
+  next.set("documentID", id);
+  return `?${next.toString()}`;
+}
+
 // eslint-disable-next-line react-refresh/only-export-components
 export const useDocumentSelector = () => {
   const context = use(DocumentSelectorContext);
@@ -59,30 +65,8 @@ export const useDocumentSelector = () => {
 };
 
 export const DocumentSelectorProvider = ({ children }: { children: ReactNode }) => {
-  type SetURLSearchParams = ReturnType<typeof useSearchParams>[1];
-
-  let searchParamsTuple: [URLSearchParams, SetURLSearchParams] | null = null;
-  try {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    searchParamsTuple = useSearchParams();
-  } catch {
-    searchParamsTuple = null;
-  }
-
-  const hasSearchParams = searchParamsTuple !== null;
-  const [searchParams, setSearchParams] =
-    searchParamsTuple ??
-    [new URLSearchParams(), (() => {}) as SetURLSearchParams];
-
-  let navigateFn: ReturnType<typeof useNavigate>;
-  let hasNavigate = true;
-  try {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    navigateFn = useNavigate();
-  } catch {
-    hasNavigate = false;
-    navigateFn = ((() => undefined) as unknown) as ReturnType<typeof useNavigate>;
-  }
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
 
   const [documentID, setDocumentIDState] = useState(
     () => searchParams.get("documentID") ?? "main",
@@ -106,36 +90,17 @@ export const DocumentSelectorProvider = ({ children }: { children: ReactNode }) 
         return;
       }
 
+      navigate(
+        { pathname: opts?.path ?? "/", search: makeSearchWithDoc(id, searchParams) },
+        { replace: !!opts?.replace },
+      );
       setDocumentIdSilently(id);
-
-      if (hasSearchParams) {
-        const nextParams = new URLSearchParams(searchParams);
-        nextParams.set("documentID", id);
-        setSearchParams(nextParams, opts?.replace ? { replace: true } : undefined);
-      }
-
-      if (hasNavigate) {
-        const path = opts?.path ?? "/";
-        navigateFn(path, opts?.replace ? { replace: true } : undefined);
-      }
     },
-    [
-      documentID,
-      hasNavigate,
-      hasSearchParams,
-      navigateFn,
-      searchParams,
-      setDocumentIdSilently,
-      setSearchParams,
-    ],
+    [documentID, navigate, searchParams, setDocumentIdSilently],
   );
 
-  const setDocumentID = useCallback(
-    (id: string) => {
-      selectDocument(id, { replace: true });
-    },
-    [selectDocument],
-  );
+  /** @deprecated Use selectDocument or setDocumentIdSilently */
+  const setDocumentID = setDocumentIdSilently;
 
   const baseProviderFactory = useMemo(
     () =>
@@ -241,10 +206,6 @@ export const DocumentSelectorProvider = ({ children }: { children: ReactNode }) 
   );
 
   useEffect(() => {
-    if (!hasSearchParams) {
-      return;
-    }
-
     const nextSearchParamId = searchParams.get("documentID");
     if (lastSearchParamIdRef.current === nextSearchParamId) {
       return;
@@ -253,7 +214,7 @@ export const DocumentSelectorProvider = ({ children }: { children: ReactNode }) 
     lastSearchParamIdRef.current = nextSearchParamId;
     const normalizedId = nextSearchParamId ?? "main";
     setDocumentIdSilently(normalizedId);
-  }, [hasSearchParams, searchParams, setDocumentIdSilently]);
+  }, [searchParams, setDocumentIdSilently]);
 
   useEffect(() => {
     if (!currentProvider) {

--- a/tests/unit/collab/document_selector.spec.ts
+++ b/tests/unit/collab/document_selector.spec.ts
@@ -10,7 +10,7 @@ async function switchDocument(context: TestContext, id: string) {
   const previousEditor = context.editor;
 
   await act(async () => {
-    context.documentSelector.setDocumentID(id);
+    context.documentSelector.setDocumentIdSilently(id);
   });
 
   await waitFor(() => context.documentSelector.documentID === id);

--- a/tests/unit/document_selector/document_session_provider.spec.tsx
+++ b/tests/unit/document_selector/document_session_provider.spec.tsx
@@ -1,0 +1,94 @@
+import { act, renderHook } from "@testing-library/react";
+import {
+  DocumentSelectorProvider,
+  useDocumentSelector,
+} from "@/features/editor/DocumentSelector/DocumentSessionProvider";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const navigateMock = vi.fn();
+const setSearchParamsMock = vi.fn();
+let currentSearchParams = new URLSearchParams();
+let setSearchParamsCalls: Array<{ params: URLSearchParams; options: { replace?: boolean } | undefined }> = [];
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: vi.fn(() => navigateMock),
+    useSearchParams: vi.fn(() => [currentSearchParams, setSearchParamsMock] as const),
+  };
+});
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <DocumentSelectorProvider>{children}</DocumentSelectorProvider>;
+}
+
+describe("document session provider navigation", () => {
+  beforeEach(() => {
+    currentSearchParams = new URLSearchParams("documentID=main");
+    setSearchParamsCalls = [];
+    navigateMock.mockReset();
+    setSearchParamsMock.mockReset();
+    setSearchParamsMock.mockImplementation((init: any, options?: { replace?: boolean }) => {
+      const next = init instanceof URLSearchParams ? init : new URLSearchParams(init);
+      currentSearchParams = new URLSearchParams(next);
+      setSearchParamsCalls.push({ params: new URLSearchParams(currentSearchParams), options });
+    });
+  });
+
+  it("selectDocument pushes a new history entry and updates the query", () => {
+    const { result } = renderHook(() => useDocumentSelector(), { wrapper });
+
+    act(() => {
+      result.current.selectDocument("secondary");
+    });
+
+    expect(result.current.documentID).toBe("secondary");
+    expect(currentSearchParams.get("documentID")).toBe("secondary");
+    expect(setSearchParamsCalls.length).toBeGreaterThanOrEqual(1);
+    expect(setSearchParamsCalls[setSearchParamsCalls.length - 1]?.options).toBeUndefined();
+    expect(navigateMock).toHaveBeenCalledWith("/", undefined);
+  });
+
+  it("selectDocument with replace does not push history", () => {
+    currentSearchParams = new URLSearchParams("documentID=initial");
+    const { result } = renderHook(() => useDocumentSelector(), { wrapper });
+
+    act(() => {
+      result.current.selectDocument("replacement", { replace: true });
+    });
+
+    expect(result.current.documentID).toBe("replacement");
+    expect(currentSearchParams.get("documentID")).toBe("replacement");
+    expect(setSearchParamsCalls.length).toBeGreaterThanOrEqual(1);
+    for (const call of setSearchParamsCalls) {
+      expect(call.options?.replace).toBe(true);
+    }
+    expect(navigateMock).toHaveBeenCalledWith("/", { replace: true });
+  });
+
+  it("setDocumentIdSilently does not touch navigation", () => {
+    const { result } = renderHook(() => useDocumentSelector(), { wrapper });
+
+    act(() => {
+      result.current.setDocumentIdSilently("silent");
+    });
+
+    expect(result.current.documentID).toBe("silent");
+    expect(currentSearchParams.get("documentID")).toBe("main");
+    expect(setSearchParamsCalls).toHaveLength(0);
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when selecting the current document", () => {
+    const { result } = renderHook(() => useDocumentSelector(), { wrapper });
+
+    act(() => {
+      result.current.selectDocument("main");
+    });
+
+    expect(setSearchParamsCalls).toHaveLength(0);
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/document_selector/document_session_provider.spec.tsx
+++ b/tests/unit/document_selector/document_session_provider.spec.tsx
@@ -7,16 +7,14 @@ import type { ReactNode } from "react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
 const navigateMock = vi.fn();
-const setSearchParamsMock = vi.fn();
 let currentSearchParams = new URLSearchParams();
-let setSearchParamsCalls: Array<{ params: URLSearchParams; options: { replace?: boolean } | undefined }> = [];
 
 vi.mock("react-router-dom", async () => {
   const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
   return {
     ...actual,
     useNavigate: vi.fn(() => navigateMock),
-    useSearchParams: vi.fn(() => [currentSearchParams, setSearchParamsMock] as const),
+    useSearchParams: vi.fn(() => [currentSearchParams, vi.fn()] as const),
   };
 });
 
@@ -27,14 +25,7 @@ function wrapper({ children }: { children: ReactNode }) {
 describe("document session provider navigation", () => {
   beforeEach(() => {
     currentSearchParams = new URLSearchParams("documentID=main");
-    setSearchParamsCalls = [];
     navigateMock.mockReset();
-    setSearchParamsMock.mockReset();
-    setSearchParamsMock.mockImplementation((init: any, options?: { replace?: boolean }) => {
-      const next = init instanceof URLSearchParams ? init : new URLSearchParams(init);
-      currentSearchParams = new URLSearchParams(next);
-      setSearchParamsCalls.push({ params: new URLSearchParams(currentSearchParams), options });
-    });
   });
 
   it("selectDocument pushes a new history entry and updates the query", () => {
@@ -45,10 +36,12 @@ describe("document session provider navigation", () => {
     });
 
     expect(result.current.documentID).toBe("secondary");
-    expect(currentSearchParams.get("documentID")).toBe("secondary");
-    expect(setSearchParamsCalls.length).toBeGreaterThanOrEqual(1);
-    expect(setSearchParamsCalls[setSearchParamsCalls.length - 1]?.options).toBeUndefined();
-    expect(navigateMock).toHaveBeenCalledWith("/", undefined);
+    expect(currentSearchParams.get("documentID")).toBe("main");
+    expect(navigateMock).toHaveBeenCalledTimes(1);
+    expect(navigateMock).toHaveBeenCalledWith(
+      { pathname: "/", search: "?documentID=secondary" },
+      { replace: false },
+    );
   });
 
   it("selectDocument with replace does not push history", () => {
@@ -60,12 +53,12 @@ describe("document session provider navigation", () => {
     });
 
     expect(result.current.documentID).toBe("replacement");
-    expect(currentSearchParams.get("documentID")).toBe("replacement");
-    expect(setSearchParamsCalls.length).toBeGreaterThanOrEqual(1);
-    for (const call of setSearchParamsCalls) {
-      expect(call.options?.replace).toBe(true);
-    }
-    expect(navigateMock).toHaveBeenCalledWith("/", { replace: true });
+    expect(currentSearchParams.get("documentID")).toBe("initial");
+    expect(navigateMock).toHaveBeenCalledTimes(1);
+    expect(navigateMock).toHaveBeenCalledWith(
+      { pathname: "/", search: "?documentID=replacement" },
+      { replace: true },
+    );
   });
 
   it("setDocumentIdSilently does not touch navigation", () => {
@@ -77,7 +70,6 @@ describe("document session provider navigation", () => {
 
     expect(result.current.documentID).toBe("silent");
     expect(currentSearchParams.get("documentID")).toBe("main");
-    expect(setSearchParamsCalls).toHaveLength(0);
     expect(navigateMock).not.toHaveBeenCalled();
   });
 
@@ -88,7 +80,6 @@ describe("document session provider navigation", () => {
       result.current.selectDocument("main");
     });
 
-    expect(setSearchParamsCalls).toHaveLength(0);
     expect(navigateMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- add `selectDocument` and `setDocumentIdSilently` helpers to the document session provider so that it owns URL updates and router navigation while keeping `setDocumentID` as a deprecated wrapper
- update the document menu to switch documents via the provider API instead of constructing `href`s and calling `navigate` directly
- add unit coverage for the new provider API and adjust the collab test to use the silent setter

## Testing
- npm run test-unit
- npm run test-browser
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_b_68dbb1ad0d1883328d5644bf2ed257e4