### PR TITLE
Fix Yjs doc initialization in collab tests

### DIFF
--- a/tests/unit/collab/document_selector.spec.ts
+++ b/tests/unit/collab/document_selector.spec.ts
@@ -34,8 +34,7 @@ async function switchDocument(context: TestContext, id: string) {
 
 const shouldRun = env.FORCE_WEBSOCKET;
 
-//FIXME re-enable
-it.runIf(shouldRun && false)("preserves independent state for each document", async (context) => {
+it.runIf(shouldRun)("preserves independent state for each document", async (context) => {
   const { load, lexicalUpdate, expect } = context;
 
   const { note0: mainNote } = load("basic");

--- a/tests/unit/common/hooks.tsx
+++ b/tests/unit/common/hooks.tsx
@@ -134,13 +134,13 @@ beforeEach(async (context) => {
     const provider = context.documentSelector.getYjsProvider();
     //wait for yjs to connect via websocket and init the editor content
     await waitForProviderSync(provider);
-
     const yDoc = context.documentSelector.getYjsDoc();
     if (yDoc) {
       yDoc.transact(() => {
         const rootXmlText = yDoc.get('root', Y.XmlText);
         rootXmlText.delete(0, rootXmlText.length);
       });
+      await waitForProviderSync(provider);
     }
   }
   if (!serializationFile && !env.VITE_PERFORMANCE_TESTS) {


### PR DESCRIPTION
## Summary
- clear the Yjs root collaboratively and wait for sync before loading fixtures in the shared test hooks to avoid stale state

## Testing
- npm run test-unit-collab document
- npm run test-unit
- npm run test-browser
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_b_68dbdfb54e5c8332bbcd3e4d9496db1b