### PR TITLE
Expose collaboration values in document session context

### DIFF
--- a/src/features/editor/DocumentSelector/DocumentSessionProvider.tsx
+++ b/src/features/editor/DocumentSelector/DocumentSessionProvider.tsx
@@ -36,8 +36,12 @@ export type ProviderFactory = (id: string, yjsDocMap: Map<string, Y.Doc>) => Pro
 export type DocumentSession = {
   id: string;
   setId: (id: string, mode?: "push" | "replace" | "silent") => void;
+  /** @deprecated Use yjsProvider */
   provider: DocumentProvider | null;
+  /** @deprecated Use yDoc */
   doc: Y.Doc | null;
+  yjsProvider: DocumentProvider | null;
+  yDoc: Y.Doc | null;
   reset: () => void;
   synced: boolean;
 };
@@ -72,7 +76,7 @@ export const DocumentSelectorProvider = ({ children }: { children: ReactNode }) 
   const yjsProviderRef = useRef<DocumentProvider | null>(null);
   const isMountedRef = useRef(true);
   const [currentProvider, setCurrentProvider] = useState<DocumentProvider | null>(null);
-  const [doc, setDoc] = useState<Y.Doc | null>(null);
+  const [currentDoc, setCurrentDoc] = useState<Y.Doc | null>(null);
   const [synced, setSynced] = useState(false);
   const lastSearchParamIdRef = useRef<string | null>(searchParams.get("documentID"));
   const [resetToken, setResetToken] = useState(0);
@@ -82,7 +86,7 @@ export const DocumentSelectorProvider = ({ children }: { children: ReactNode }) 
       return;
     }
     // eslint-disable-next-line react-hooks-extra/no-direct-set-state-in-use-effect
-    setDoc((prev) => (prev === next ? prev : next));
+    setCurrentDoc((prev) => (prev === next ? prev : next));
   }, []);
 
   const setDocumentIdSilently = useCallback((id: string) => {
@@ -211,12 +215,14 @@ export const DocumentSelectorProvider = ({ children }: { children: ReactNode }) 
         id: documentID,
         setId,
         provider: currentProvider,
-        doc,
+        doc: currentDoc,
+        yjsProvider: currentProvider,
+        yDoc: currentDoc,
         reset,
         synced,
       } satisfies DocumentSession;
     },
-    [currentProvider, doc, documentID, reset, setId, synced, resetToken],
+    [currentDoc, currentProvider, documentID, reset, setId, synced, resetToken],
   );
 
   useEffect(() => {
@@ -282,11 +288,11 @@ export const DocumentSelectorProvider = ({ children }: { children: ReactNode }) 
   );
 };
 
-/** @deprecated Use session.provider instead */
-export const getYjsProvider = () => legacySessionRef.current?.provider ?? null;
+/** @deprecated Use session.yjsProvider instead */
+export const getYjsProvider = () => legacySessionRef.current?.yjsProvider ?? null;
 
-/** @deprecated Use session.doc instead */
-export const getYjsDoc = () => legacySessionRef.current?.doc ?? null;
+/** @deprecated Use session.yDoc instead */
+export const getYjsDoc = () => legacySessionRef.current?.yDoc ?? null;
 
 /** @deprecated Use useCollabFactory() */
 export const yjsProviderFactory = undefined as unknown as ProviderFactory;

--- a/src/features/editor/Editor.tsx
+++ b/src/features/editor/Editor.tsx
@@ -36,7 +36,7 @@ function LexicalEditor() {
   return (
     <LexicalComposer
       initialConfig={editorConfig}
-      key={`${session.id}:${session.doc?.guid ?? "local"}`}
+      key={`${session.id}:${session.yDoc?.guid ?? "local"}`}
     >
       <div className="editor-container editor-shell">
         <DevToolbarPlugin editorBottomRef={editorBottomRef} />

--- a/src/features/editor/devtools/DevToolbarPlugin.tsx
+++ b/src/features/editor/devtools/DevToolbarPlugin.tsx
@@ -104,7 +104,7 @@ export const DevToolbarPlugin = ({ editorBottomRef }) => {
   }
 
   const clearContent = () => {
-    const provider = session.provider;
+    const provider = session.yjsProvider;
     if (provider) {
       session.reset();
       return;

--- a/tests/unit/collab/document_selector.spec.ts
+++ b/tests/unit/collab/document_selector.spec.ts
@@ -15,10 +15,10 @@ async function switchDocument(context: TestContext, id: string) {
 
   await waitFor(() => context.documentSelector.id === id);
   await waitFor(() => context.editor !== previousEditor);
-  await waitFor(() => context.documentSelector.provider !== null);
-  await waitFor(() => context.documentSelector.provider?.synced === true, { timeout: 5000 });
+  await waitFor(() => context.documentSelector.yjsProvider !== null);
+  await waitFor(() => context.documentSelector.yjsProvider?.synced === true, { timeout: 5000 });
   await waitFor(() => {
-    const doc = context.documentSelector.doc;
+    const doc = context.documentSelector.yDoc;
     if (!doc) {
       return false;
     }
@@ -44,7 +44,7 @@ it.runIf(shouldRun && false)("preserves independent state for each document", as
 
   await waitFor(
     () => {
-      const doc = context.documentSelector.doc;
+      const doc = context.documentSelector.yDoc;
       if (!doc) {
         return false;
       }
@@ -67,7 +67,7 @@ it.runIf(shouldRun && false)("preserves independent state for each document", as
 
   await waitFor(
     () => {
-      const doc = context.documentSelector.doc;
+      const doc = context.documentSelector.yDoc;
       if (!doc) {
         return false;
       }
@@ -84,7 +84,7 @@ it.runIf(shouldRun && false)("preserves independent state for each document", as
   await switchDocument(context, "main");
 
   await waitFor(() => {
-    const doc = context.documentSelector.doc;
+    const doc = context.documentSelector.yDoc;
     if (!doc) {
       return false;
     }
@@ -99,7 +99,7 @@ it.runIf(shouldRun && false)("preserves independent state for each document", as
   await switchDocument(context, "flat");
 
   await waitFor(() => {
-    const doc = context.documentSelector.doc;
+    const doc = context.documentSelector.yDoc;
     if (!doc) {
       return false;
     }

--- a/tests/unit/common/hooks.tsx
+++ b/tests/unit/common/hooks.tsx
@@ -131,11 +131,11 @@ beforeEach(async (context) => {
   logger.setFlushFunction(() => context.lexicalUpdate(() => { }));
 
   if (env.FORCE_WEBSOCKET) {
-    const provider = context.documentSelector.provider;
+    const provider = context.documentSelector.yjsProvider;
     //wait for yjs to connect via websocket and init the editor content
     await waitForProviderSync(provider);
 
-    const yDoc = context.documentSelector.doc;
+    const yDoc = context.documentSelector.yDoc;
     if (yDoc) {
       yDoc.transact(() => {
         const rootXmlText = yDoc.get('root', Y.XmlText);
@@ -158,7 +158,7 @@ beforeEach(async (context) => {
 
 afterEach(async (context) => {
   if (env.FORCE_WEBSOCKET) {
-    const provider = context.documentSelector?.provider;
+    const provider = context.documentSelector?.yjsProvider;
     if (provider instanceof WebsocketProvider) {
       await waitForProviderSync(provider);
     }


### PR DESCRIPTION
## Summary
- expose yjsProvider and yDoc on the document session context and route legacy shims through the new fields
- rely on the collab factory hook inside the editor and switch dev tooling to the new yjsProvider value
- update collaboration-focused tests to consume the renamed context values

## Testing
- npm run test-unit
- npm run test-browser
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_b_68dbf27cafb48332b13fd700582c850e