### PR TITLE
Refactor collaboration provider typing and disable flag

### DIFF
--- a/src/features/editor/DocumentSelector/DocumentSessionProvider.tsx
+++ b/src/features/editor/DocumentSelector/DocumentSessionProvider.tsx
@@ -24,14 +24,14 @@ type YWebsocketEvents = {
   destroy: () => void;
 };
 
-type TypedProvider = WebsocketProvider & {
-  on<K extends keyof YWebsocketEvents>(event: K, callback: YWebsocketEvents[K]): void;
-  off<K extends keyof YWebsocketEvents>(event: K, callback: YWebsocketEvents[K]): void;
-};
+export type DocumentProvider = Provider &
+  (WebsocketProvider & {
+    on<K extends keyof YWebsocketEvents>(event: K, callback: YWebsocketEvents[K]): void;
+    off<K extends keyof YWebsocketEvents>(event: K, callback: YWebsocketEvents[K]): void;
+    synced?: boolean;
+  });
 
-export type DocumentProvider = Provider & TypedProvider;
-
-export type ProviderFactory = (id: string, yjsDocMap: Map<string, Y.Doc>) => Provider;
+export type ProviderFactory = (id: string, yjsDocMap: Map<string, Y.Doc>) => DocumentProvider;
 
 export type DocumentSession = {
   id: string;
@@ -40,6 +40,7 @@ export type DocumentSession = {
   yDoc: Y.Doc | null;
   reset: () => void;
   synced: boolean;
+  collabDisabled: boolean;
 };
 
 const DocumentSessionContext = createContext<DocumentSession | null>(null);
@@ -67,6 +68,7 @@ export const DocumentSelectorProvider = ({ children }: { children: ReactNode }) 
     () => searchParams.get("documentID") ?? "main",
   );
   const editorConfig = useEditorConfig();
+  const collabDisabled = editorConfig.collabDisabled;
   const yjsDocs = useRef(new Map<string, Y.Doc>());
   const yjsProviderRef = useRef<DocumentProvider | null>(null);
   const isMountedRef = useRef(true);
@@ -134,6 +136,9 @@ export const DocumentSelectorProvider = ({ children }: { children: ReactNode }) 
 
   const collaborationProviderFactory: ProviderFactory = useCallback(
     (id: string, yjsDocMap: Map<string, Y.Doc>) => {
+      if (collabDisabled) {
+        throw new Error("Collaboration is disabled; no provider is available.");
+      }
       const storedDoc = yjsDocs.current.get(id) ?? null;
       if (storedDoc && !yjsDocMap.has(id)) {
         yjsDocMap.set(id, storedDoc);
@@ -173,7 +178,7 @@ export const DocumentSelectorProvider = ({ children }: { children: ReactNode }) 
 
       return provider;
     },
-    [baseProviderFactory, documentID, scheduleSetDoc],
+    [baseProviderFactory, collabDisabled, documentID, scheduleSetDoc],
   );
 
   const reset = useCallback(() => {
@@ -210,8 +215,9 @@ export const DocumentSelectorProvider = ({ children }: { children: ReactNode }) 
         yDoc: currentDoc,
         reset,
         synced,
+        collabDisabled,
       }) satisfies DocumentSession,
-    [currentDoc, currentProvider, documentID, reset, setId, synced],
+    [collabDisabled, currentDoc, currentProvider, documentID, reset, setId, synced],
   );
 
   useEffect(() => {
@@ -247,7 +253,7 @@ export const DocumentSelectorProvider = ({ children }: { children: ReactNode }) 
   }, [currentProvider]);
 
   useEffect(() => {
-    if (!editorConfig.disableWS) {
+    if (!collabDisabled) {
       return;
     }
 
@@ -259,7 +265,7 @@ export const DocumentSelectorProvider = ({ children }: { children: ReactNode }) 
     yjsDocs.current.clear();
     yjsProviderRef.current = null;
     scheduleSetDoc(null);
-  }, [editorConfig.disableWS, scheduleSetDoc]);
+  }, [collabDisabled, scheduleSetDoc]);
 
   return (
     <CollabFactoryContext value={collaborationProviderFactory}>

--- a/src/features/editor/Editor.tsx
+++ b/src/features/editor/Editor.tsx
@@ -21,13 +21,13 @@ import { RemdoPlugin } from "./plugins/RemdoPlugin";
 import { RichTextPlugin } from "@lexical/react/LexicalRichTextPlugin";
 import { TabIndentationPlugin } from "@lexical/react/LexicalTabIndentationPlugin";
 import { RemdoListPlugin } from "./plugins/remdo/RemdoListPlugin";
-import { useDisableCollaboration, useEditorConfig } from "./config";
+import { useEditorConfig } from "./config";
 
 function LexicalEditor() {
-  const disableCollaboration = useDisableCollaboration();
   const editorContainerRef = useRef<HTMLDivElement | null>(null);
   const editorBottomRef = useRef<HTMLDivElement | null>(null);
   const session = useDocumentSelector();
+  const collabDisabled = session.collabDisabled;
   const collabFactory = useCollabFactory();
   const editorConfig = useEditorConfig();
   const shouldMountTestBridge =
@@ -60,7 +60,7 @@ function LexicalEditor() {
         <LinkPlugin />
         <LexicalClickableLinkPlugin />
         <TabIndentationPlugin />
-        {disableCollaboration ? (
+        {collabDisabled ? (
           <HistoryPlugin />
         ) : (
           <LexicalCollaboration>

--- a/src/features/editor/config.ts
+++ b/src/features/editor/config.ts
@@ -1,23 +1,38 @@
 import { AutoLinkNode, LinkNode } from "@lexical/link";
 import { ListItemNode, ListNode } from "@lexical/list";
 import type { InitialConfigType } from "@lexical/react/LexicalComposer";
-import { useMemo } from "react";
+import { useRef } from "react";
 import { useSearchParams } from "react-router-dom";
 
-type EditorConfig = InitialConfigType & { disableWS: boolean };
+type EditorConfig = InitialConfigType & { collabDisabled: boolean };
 
-export function useDisableCollaboration(): boolean {
+let hasWarnedDisableWsParam = false;
+
+export function useCollaborationDisabled(): boolean {
   const [searchParams] = useSearchParams();
+  const collabDisabledRef = useRef<boolean | null>(null);
 
-  // intentionally set it on the first render, so further actions
-  // like focusing on a particular node, won't impact the setting even if the
-  // url changes
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  return useMemo(() => searchParams.get("ws") === "false", []);
+  if (collabDisabledRef.current === null) {
+    const collabParam = searchParams.get("collab");
+    if (collabParam !== null) {
+      collabDisabledRef.current = collabParam === "false";
+    } else {
+      const legacyParam = searchParams.get("ws");
+      if (legacyParam === "false" && !hasWarnedDisableWsParam && import.meta.env.DEV) {
+        console.warn(
+          "`ws=false` is deprecated. Use `collab=false` to disable collaboration.",
+        );
+        hasWarnedDisableWsParam = true;
+      }
+      collabDisabledRef.current = legacyParam === "false";
+    }
+  }
+
+  return collabDisabledRef.current ?? false;
 }
 
 export function useEditorConfig(): EditorConfig {
-  const disableWS = useDisableCollaboration();
+  const collabDisabled = useCollaborationDisabled();
 
   return {
     onError(error: any) {
@@ -42,6 +57,6 @@ export function useEditorConfig(): EditorConfig {
       },
     },
     editorState: null,
-    disableWS, //TODO remove or rename
+    collabDisabled,
   };
 }

--- a/src/features/editor/plugins/remdo/RootSchemaPlugin.tsx
+++ b/src/features/editor/plugins/remdo/RootSchemaPlugin.tsx
@@ -8,7 +8,6 @@ import {
 } from "@lexical/list";
 
 import { useRemdoLexicalComposerContext } from "@/features/editor/plugins/remdo/ComposerContext";
-import { useDisableCollaboration } from "@/features/editor/config";
 import { useDocumentSelector } from "@/features/editor/DocumentSelector/DocumentSessionProvider";
 import { mergeLists } from "./utils/unexported";
 
@@ -62,24 +61,22 @@ function $ensureSingleListRoot(rootNode: RootNode): void {
 
 export function RootSchemaPlugin(): null {
   const [editor] = useRemdoLexicalComposerContext();
-  //FIXME review and simplify once collab is refactored
-  const disableCollaboration = useDisableCollaboration();
-  const { synced } = useDocumentSelector();
+  const { collabDisabled, synced } = useDocumentSelector();
   const serializationFile = import.meta.env.VITEST_SERIALIZATION_FILE;
   const disableForSerialization = Boolean(serializationFile);
-  const hasSynced = disableForSerialization || disableCollaboration || synced;
+  const hasSynced = disableForSerialization || collabDisabled || synced;
 
   useEffect(() => {
     if (disableForSerialization) {
       return;
     }
 
-    if (!disableCollaboration && !hasSynced) {
+    if (!collabDisabled && !hasSynced) {
       return;
     }
 
     return editor.registerNodeTransform(RootNode, $ensureSingleListRoot);
-  }, [disableCollaboration, disableForSerialization, editor, hasSynced]);
+  }, [collabDisabled, disableForSerialization, editor, hasSynced]);
 
   return null;
 }

--- a/src/features/editor/plugins/remdo/YjsPlugin.tsx
+++ b/src/features/editor/plugins/remdo/YjsPlugin.tsx
@@ -1,5 +1,3 @@
-// @ts-nocheck
-// TODO(remdo): Restore YjsPlugin typing once collaboration wiring migrates to the new provider abstraction.
 import { useEffect, useRef } from "react";
 import { useRemdoLexicalComposerContext } from "./ComposerContext";
 import { YJS_SYNCED_COMMAND } from "./utils/commands";

--- a/src/test-harness/RemdoTestBridge.tsx
+++ b/src/test-harness/RemdoTestBridge.tsx
@@ -44,7 +44,11 @@ export default function RemdoTestBridge(): null {
 function createAPI(editor: LexicalEditor) {
   const disposables: Array<() => void> = [];
   const searchParams = new URLSearchParams(window.location.search);
-  const collabEnabled = searchParams.get("ws") !== "false";
+  const collabParam = searchParams.get("collab");
+  const legacyWsParam = searchParams.get("ws");
+  const collabDisabled =
+    collabParam !== null ? collabParam === "false" : legacyWsParam === "false";
+  const collabEnabled = !collabDisabled;
   let isYjsSynced = !collabEnabled;
 
   type Waiter = {

--- a/tests/unit/common/hooks.tsx
+++ b/tests/unit/common/hooks.tsx
@@ -58,7 +58,7 @@ beforeEach(async (context) => {
 
 
   if (!env.FORCE_WEBSOCKET) {
-    urlParams.push(['ws', 'false']);
+    urlParams.push(['collab', 'false']);
   } else {
     logger.info("Collab enabled");
   }

--- a/tests/unit/document_selector/document_session_provider.spec.tsx
+++ b/tests/unit/document_selector/document_session_provider.spec.tsx
@@ -3,11 +3,23 @@ import {
   DocumentSelectorProvider,
   useDocumentSelector,
 } from "@/features/editor/DocumentSelector/DocumentSessionProvider";
+import { useCollabFactory } from "@/features/editor/DocumentSelector/useCollabFactory";
+import type {
+  CollaborationProviderFactory,
+  CreateCollaborationProviderFactoryOptions,
+} from "@/features/editor/collab/createCollaborationProviderFactory";
 import type { ReactNode } from "react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
 const navigateMock = vi.fn();
 let currentSearchParams = new URLSearchParams();
+
+let actualCreateCollaborationProviderFactory:
+  | ((options?: CreateCollaborationProviderFactoryOptions) => CollaborationProviderFactory)
+  | null = null;
+const createCollaborationProviderFactoryMock = vi.fn<
+  (options?: CreateCollaborationProviderFactoryOptions) => CollaborationProviderFactory
+>();
 
 vi.mock("react-router-dom", async () => {
   const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
@@ -18,14 +30,39 @@ vi.mock("react-router-dom", async () => {
   };
 });
 
+vi.mock("@/features/editor/collab/createCollaborationProviderFactory", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/features/editor/collab/createCollaborationProviderFactory")
+  >("@/features/editor/collab/createCollaborationProviderFactory");
+  return {
+    ...actual,
+    createCollaborationProviderFactory: (
+      ...args: Parameters<typeof actual.createCollaborationProviderFactory>
+    ) => createCollaborationProviderFactoryMock(...args),
+  };
+});
+
 function wrapper({ children }: { children: ReactNode }) {
   return <DocumentSelectorProvider>{children}</DocumentSelectorProvider>;
 }
 
 describe("document session provider navigation", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     currentSearchParams = new URLSearchParams("documentID=main");
     navigateMock.mockReset();
+    createCollaborationProviderFactoryMock.mockReset();
+    if (!actualCreateCollaborationProviderFactory) {
+      const actual = await vi.importActual<
+        typeof import("@/features/editor/collab/createCollaborationProviderFactory")
+      >("@/features/editor/collab/createCollaborationProviderFactory");
+      actualCreateCollaborationProviderFactory = actual.createCollaborationProviderFactory;
+    }
+    createCollaborationProviderFactoryMock.mockImplementation((options) => {
+      if (!actualCreateCollaborationProviderFactory) {
+        throw new Error("Expected actual createCollaborationProviderFactory to be available");
+      }
+      return actualCreateCollaborationProviderFactory(options);
+    });
   });
 
   it("setId pushes a new history entry and updates the query by default", () => {
@@ -81,5 +118,22 @@ describe("document session provider navigation", () => {
     });
 
     expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it("does not create a provider when collaboration is disabled", () => {
+    const providerFactorySpy = vi.fn(() => {
+      throw new Error("Provider factory should not be called when disabled");
+    });
+    createCollaborationProviderFactoryMock.mockImplementation(() => providerFactorySpy);
+    currentSearchParams = new URLSearchParams("documentID=main&collab=false");
+
+    const { result: sessionResult } = renderHook(() => useDocumentSelector(), { wrapper });
+    const { result: factoryResult } = renderHook(() => useCollabFactory(), { wrapper });
+
+    expect(sessionResult.current.collabDisabled).toBe(true);
+    expect(() => factoryResult.current("main", new Map())).toThrowError(
+      /Collaboration is disabled/i,
+    );
+    expect(providerFactorySpy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- rename the editor configuration flag to `collabDisabled`, add a typed provider shim, and surface the flag on the document session context
- remove `@ts-nocheck` from the Yjs plugin and rely on the typed `YJS_SYNCED_COMMAND`
- update the Remdo test bridge, shared hooks, and document selector tests to use the new collaboration flag and verify providers are skipped when disabled

## Testing
- npm run test-unit
- npm run test-browser
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_b_68dbfe39282c83328e54cd848dbe2566