### PR TITLE
chore: configure dependabot weekly grouped updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,12 +3,23 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-        interval: "daily"
+        interval: "weekly"
+        day: "sunday"
+    groups:
+        all-dependencies:
+            patterns:
+                - "*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-        interval: "daily"
+        interval: "weekly"
+        day: "sunday"
+    groups:
+        all-actions:
+            patterns:
+                - "*"
   - package-ecosystem: "gitsubmodule"
     directory: "/"
     schedule:
-        interval: "daily"
+        interval: "weekly"
+        day: "sunday"


### PR DESCRIPTION
## Summary
- schedule Dependabot updates weekly for npm, GitHub Actions, and git submodules
- group npm and GitHub Actions updates into single pull requests

## Testing
- npm run lint
- npm run typecheck
- npm run test-unit
- npm run test-browser

------
https://chatgpt.com/codex/tasks/task_b_68dcd5efd24c8332bac56004c207cb61