### PR TITLE
Embed collaboration disabled flag in config

### DIFF
--- a/src/features/editor/Editor.tsx
+++ b/src/features/editor/Editor.tsx
@@ -32,13 +32,10 @@ function LexicalEditor() {
   const editorConfig = useEditorConfig();
   const shouldMountTestBridge =
     !import.meta.env.PROD || (typeof window !== "undefined" && window.REMDO_TEST === true);
-  const lexicalConfig = collabDisabled
-    ? editorConfig
-    : { ...editorConfig, collaboration: { providerFactory: collabFactory } };
 
   return (
     <LexicalComposer
-      initialConfig={lexicalConfig}
+      initialConfig={editorConfig}
       key={session.editorKey}
     >
       <div className="editor-container editor-shell">

--- a/src/features/editor/config.ts
+++ b/src/features/editor/config.ts
@@ -4,7 +4,16 @@ import type { InitialConfigType } from "@lexical/react/LexicalComposer";
 import { useRef } from "react";
 import { useSearchParams } from "react-router-dom";
 
-type EditorConfig = InitialConfigType & { collabDisabled: boolean };
+import { useCollabFactory } from "./collab/useCollabFactory";
+import type { ProviderFactory } from "./collab/types";
+
+type CollaborationConfig =
+  | { disabled: true }
+  | { disabled?: false; providerFactory: ProviderFactory };
+
+type EditorConfig = InitialConfigType & {
+  collaboration: CollaborationConfig;
+};
 
 export function useCollaborationDisabled(): boolean {
   const [searchParams] = useSearchParams();
@@ -20,6 +29,10 @@ export function useCollaborationDisabled(): boolean {
 
 export function useEditorConfig(): EditorConfig {
   const collabDisabled = useCollaborationDisabled();
+  const collabFactory = useCollabFactory();
+  const collaboration = collabDisabled
+    ? ({ disabled: true } as const)
+    : ({ providerFactory: collabFactory } satisfies CollaborationConfig);
 
   return {
     onError(error: any) {
@@ -44,6 +57,6 @@ export function useEditorConfig(): EditorConfig {
       },
     },
     editorState: null,
-    collabDisabled,
+    collaboration,
   };
 }


### PR DESCRIPTION
## Summary
- embed the disabled flag within the collaboration configuration returned by `useEditorConfig`
- ensure the collaboration config always resolves to either a disabled marker or the provider factory

## Testing
- npm run lint
- npm run typecheck
- npm run test-unit
- npm run test-browser

------
https://chatgpt.com/codex/tasks/task_b_68dcf3ca42b4833293c30220cb45fd34