### PR TITLE
Refine browser report publishing workflows

### DIFF
--- a/.github/workflows/publish-browser-report.yml
+++ b/.github/workflows/publish-browser-report.yml
@@ -1,0 +1,34 @@
+name: Publish Browser Report
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: ID of the workflow run that produced the report
+        required: true
+
+permissions:
+  actions: read
+  pages: write
+  id-token: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Pages artifact
+        uses: actions/download-artifact@v5
+        with:
+          name: github-pages
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.run_id }}
+          path: github-pages
+
+      - name: Upload artifact for deployment
+        uses: actions/upload-pages-artifact@v3
+        with:
+          name: github-pages
+          path: github-pages
+
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/test-browser-collab.yml
+++ b/.github/workflows/test-browser-collab.yml
@@ -5,91 +5,22 @@ on:
   workflow_dispatch:
 
 permissions:
-  actions: read
   contents: read
-  pages: write
-  id-token: write
-
-concurrency:
-  group: pages-${{ github.ref }}
-  cancel-in-progress: false
 
 jobs:
   run:
     runs-on: ubuntu-latest
-    outputs:
-      report_present: ${{ steps.playwright.outputs.report_present }}
-      slug: ${{ steps.playwright.outputs.slug }}
     steps:
       - uses: actions/checkout@v5
 
       - name: Run Playwright suite
-        id: playwright
         uses: ./.github/actions/test-browser-shared
         with:
           command: npm run test-browser-collab
 
-  prepare-pages:
-    if: ${{ always() && needs.run.outputs.report_present == 'true' && (github.ref_name == 'main' || startsWith(github.ref_name, 'codex/')) }}
-    needs: run
-    runs-on: ubuntu-latest
-    env:
-      BRANCH_SLUG: ${{ needs.run.outputs.slug }}
-    steps:
-      - uses: actions/checkout@v5
+      - name: Upload Playwright report
+        if: ${{ hashFiles('data/playwright-report/index.html') != '' }}
+        uses: actions/upload-pages-artifact@v3
         with:
-          fetch-depth: 0
-
-      - name: Download test artifacts
-        uses: actions/download-artifact@v5
-        with:
-          name: data
-          path: data
-
-      - name: Fetch existing GitHub Pages content
-        run: |
-          set -euo pipefail
-          if git ls-remote --exit-code origin gh-pages &>/dev/null; then
-            git fetch origin gh-pages:gh-pages
-            git worktree add gh-pages-source gh-pages
-          fi
-
-      - name: Prepare Pages artifact
-        run: |
-          set -euo pipefail
-          mkdir -p pages/branches
-          if [ -d gh-pages-source ]; then
-            rsync -a --delete --exclude '.git' gh-pages-source/ pages/
-          fi
-          rm -rf pages/playwright-report
-          rm -rf "pages/branches/${BRANCH_SLUG}"
-          mv data/playwright-report "pages/branches/${BRANCH_SLUG}"
-          cd pages/branches
-          ls -1t | tail -n +21 | xargs -r rm -rf
-          cd ../..
-
-      - name: Upload Playwright report to GitHub Pages
-        uses: actions/upload-pages-artifact@v4
-        with:
-          path: pages
-
-  deploy:
-    if: ${{ needs.prepare-pages.result == 'success' }}
-    needs:
-      - run
-      - prepare-pages
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ format('{0}branches/{1}/', steps.deployment.outputs.page_url, needs.run.outputs.slug) }}
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
-      - name: Log report location
-        env:
-          REPORT_URL: ${{ format('{0}branches/{1}/', steps.deployment.outputs.page_url, needs.run.outputs.slug) }}
-          BRANCH_SLUG: ${{ needs.run.outputs.slug }}
-        run: |
-          set -euo pipefail
-          echo "Playwright report for branch '${BRANCH_SLUG}' available at: ${REPORT_URL}"
+          name: github-pages
+          path: data/playwright-report

--- a/.github/workflows/test-browser.yml
+++ b/.github/workflows/test-browser.yml
@@ -15,3 +15,10 @@ jobs:
         uses: ./.github/actions/test-browser-shared
         with:
           command: npm run test-browser
+
+      - name: Upload Playwright report
+        if: ${{ hashFiles('data/playwright-report/index.html') != '' }}
+        uses: actions/upload-pages-artifact@v3
+        with:
+          name: github-pages
+          path: data/playwright-report


### PR DESCRIPTION
## Summary
- stop automatically deploying browser test reports and upload a consistent `github-pages` artifact when an HTML report exists
- add a manual workflow that downloads a run's `github-pages` artifact and deploys it to Pages on demand

## Testing
- npm run lint
- npm run typecheck
- npm run test-unit
- npm run test-browser

------
https://chatgpt.com/codex/tasks/task_b_68dcf8c8efe0833283a65ed770d99d66