### PR TITLE
Add env setup script and simplify node test action

### DIFF
--- a/.github/actions/node-test-shared/action.yml
+++ b/.github/actions/node-test-shared/action.yml
@@ -15,38 +15,17 @@ runs:
       with:
         node-version: 22
 
-    - name: Install dependencies
-      shell: bash
-      run: npm ci --no-audit --no-fund
-
-    - name: Start WebSocket server
-      if: ${{ inputs.websocket == 'true' }}
+    - name: Bootstrap environment
       shell: bash
       run: |
-        set -euo pipefail
-        npm run websocket &
-        echo $! > ws-server.pid
-        for _ in {1..20}; do
-          if nc -z localhost 8080; then
-            exit 0
-          fi
-          sleep 1
-        done
-        echo "WebSocket server failed to start" >&2
-        exit 1
+        if [ "${{ inputs.websocket }}" = "true" ]; then
+          scripts/env-setup.sh --collab
+        else
+          scripts/env-setup.sh
+        fi
 
     - name: Run command
       shell: bash
       env:
         FORCE_COLOR: "1"
       run: ${{ inputs.command }}
-
-    - name: Stop WebSocket server
-      if: ${{ always() && inputs.websocket == 'true' }}
-      shell: bash
-      run: |
-        set -euo pipefail
-        if [ -f ws-server.pid ]; then
-          kill $(cat ws-server.pid) || true
-          rm -f ws-server.pid
-        fi

--- a/scripts/env-setup.sh
+++ b/scripts/env-setup.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# scripts/env-setup.sh
+# Minimal, detached environment bootstrap for CI/Codex/local.
+set -Eeuo pipefail
+
+# ---- hardcoded settings (keep simple) ----------------------------------------
+TIMEOUT_MS=20000     # wait up to 20s for the collab websocket to accept connections
+HOST=127.0.0.1
+PORT="${REMDO_WS_PORT:-8080}"
+
+# ---- args --------------------------------------------------------------------
+COLLAB=false
+SKIP_PLAYWRIGHT=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --collab) COLLAB=true; shift ;;
+    --skip-playwright) SKIP_PLAYWRIGHT=true; shift ;;
+    -h|--help)
+      echo "Usage: $0 [--collab] [--skip-playwright]"; exit 0 ;;
+    *) echo "Unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+
+# ---- deps --------------------------------------------------------------------
+npm ci --no-audit --no-fund
+$SKIP_PLAYWRIGHT || npx playwright install --with-deps chromium || true
+
+# ---- optionally start collab websocket (detached) ----------------------------
+if $COLLAB; then
+  # Start if port not yet accepting connections
+  node -e '
+    const net=require("net");
+    const [h,p]=process.argv.slice(1); const s=net.connect({host:h,port:+p},()=>{s.end();process.exit(0);});
+    s.on("error",()=>process.exit(1));
+  ' "$HOST" "$PORT" >/dev/null 2>&1 || {
+    nohup npm run --silent websocket >/tmp/remdo-ws.log 2>&1 &
+  }
+
+  # Wait until port is live (or fail)
+  node -e '
+    const net=require("net");
+    const [h,p,ms]=process.argv.slice(1); const deadline=Date.now()+(+ms);
+    (function tryConnect(){
+      const s=net.connect({host:h,port:+p},()=>{s.end();process.exit(0);});
+      s.on("error",()=>{s.destroy(); Date.now()>deadline?process.exit(1):setTimeout(tryConnect,250);});
+    })();
+  ' "$HOST" "$PORT" "$TIMEOUT_MS" || {
+    echo "[env-setup] websocket failed to start on ${HOST}:${PORT} within ${TIMEOUT_MS}ms" >&2
+    tail -n 80 /tmp/remdo-ws.log 2>/dev/null || true
+    exit 1
+  }
+
+  echo "[env-setup] websocket is up on ${HOST}:${PORT}"
+fi


### PR DESCRIPTION
## Summary
- add a minimal scripts/env-setup.sh bootstrap script with optional collab websocket support
- update the node-test-shared composite action to use the bootstrap script instead of inlining setup logic

## Testing
- npm run test-unit
- npm run test-browser
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_b_68dd183bf6148332becf8c308cc4f793