### PR TITLE
Add regression tests for root schema normalization

### DIFF
--- a/tests/unit/root_schema_plugin.spec.ts
+++ b/tests/unit/root_schema_plugin.spec.ts
@@ -1,0 +1,65 @@
+import "./common"; // imported for side effects
+
+import { $isListNode } from "@lexical/list";
+import {
+  $createTextNode,
+  $getRoot,
+  ParagraphNode,
+} from "lexical";
+import { it } from "vitest";
+
+it("wraps top-level paragraph nodes created by paste into the root list", async ({
+  editor,
+  lexicalUpdate,
+  expect,
+}) => {
+  lexicalUpdate(() => {
+    const root = $getRoot();
+
+    // Simulate a DOM paste that inserts a top-level paragraph into the editor.
+    const paragraph = new ParagraphNode();
+    paragraph.append($createTextNode("Paragraph from paste"));
+
+    root.clear();
+    root.append(paragraph);
+  });
+
+  await expect(editor).toMatchNoteTree([{ text: "Paragraph from paste" }]);
+
+  lexicalUpdate(() => {
+    const root = $getRoot();
+    expect(root.getChildren()).toHaveLength(1);
+    expect($isListNode(root.getFirstChild())).toBe(true);
+  });
+});
+
+it("merges stray paragraphs that end up after the root list", async ({
+  load,
+  editor,
+  lexicalUpdate,
+  expect,
+}) => {
+  load("basic");
+
+  lexicalUpdate(() => {
+    const root = $getRoot();
+    const list = root.getFirstChild();
+    const paragraph = new ParagraphNode();
+    paragraph.append($createTextNode("Pasted below root"));
+
+    // Simulate pasting multiple paragraphs where Lexical temporarily appends
+    // a paragraph next to the root list node.
+    list?.insertAfter(paragraph);
+  });
+
+  await expect(editor).toMatchNoteTree([
+    { text: "note0", children: [{ text: "note00" }] },
+    { text: "Pasted below root" },
+  ]);
+
+  lexicalUpdate(() => {
+    const root = $getRoot();
+    expect(root.getChildren()).toHaveLength(1);
+    expect($isListNode(root.getFirstChild())).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests that simulate paste scenarios to verify RootSchemaPlugin normalization

## Testing
- npm run test-unit
- npm run test-browser
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_b_68de48a3a4ac8332b3f1e66981100571