### PR TITLE
Ensure pnpm is installed after Node setup in typecheck workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "sunday"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,34 @@
+name: Typecheck
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.18.1
+
+      - name: Verify pnpm
+        run: pnpm --version
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run typecheck
+        run: pnpm typecheck


### PR DESCRIPTION
## Summary
- set up Node before installing pnpm so the typecheck workflow retains the pnpm binary on PATH
- add cache configuration for pnpm and verify the installed pnpm version during CI

## Testing
- pnpm run test *(fails: Missing script: test)*
- pnpm run browser *(fails: Missing script: browser)*
- pnpm lint *(fails: Command "lint" not found)*
- pnpm typecheck

------
https://chatgpt.com/codex/tasks/task_b_68e6aa6f7eec83329def64a8fabc9bfb