### PR TITLE
Add shared pnpm setup action for lint and unit tests

### DIFF
--- a/.github/actions/pnpm-setup/action.yml
+++ b/.github/actions/pnpm-setup/action.yml
@@ -1,0 +1,22 @@
+name: Setup pnpm workspace
+description: Set up Node.js and install dependencies using pnpm
+inputs:
+  node-version:
+    description: Node.js version to use
+    default: '22'
+    required: false
+runs:
+  using: composite
+  steps:
+    - name: Checkout repository
+      uses: actions/checkout@v5
+    - name: Setup pnpm
+      uses: pnpm/action-setup@v4
+    - name: Setup Node.js
+      uses: actions/setup-node@v5
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: pnpm
+    - name: Install dependencies
+      run: pnpm install --frozen-lockfile
+      shell: bash

--- a/.github/actions/pnpm-setup/action.yml
+++ b/.github/actions/pnpm-setup/action.yml
@@ -8,8 +8,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Checkout repository
-      uses: actions/checkout@v5
     - name: Setup Node.js
       uses: actions/setup-node@v5
       with:

--- a/.github/actions/pnpm-setup/action.yml
+++ b/.github/actions/pnpm-setup/action.yml
@@ -5,10 +5,6 @@ inputs:
     description: Node.js version to use
     default: '22'
     required: false
-  pnpm-version:
-    description: pnpm version to install
-    default: '10.18.1'
-    required: false
 runs:
   using: composite
   steps:
@@ -22,7 +18,6 @@ runs:
     - name: Setup pnpm
       uses: pnpm/action-setup@v4
       with:
-        version: ${{ inputs.pnpm-version }}
         run_install: false
     - name: Install dependencies
       run: pnpm install --frozen-lockfile

--- a/.github/actions/pnpm-setup/action.yml
+++ b/.github/actions/pnpm-setup/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: Node.js version to use
     default: '22'
     required: false
+  pnpm-version:
+    description: pnpm version to activate via Corepack
+    default: latest
+    required: false
 runs:
   using: composite
   steps:
@@ -14,7 +18,10 @@ runs:
         node-version: ${{ inputs.node-version }}
         cache: pnpm
     - name: Enable Corepack
-      run: corepack enable
+      run: corepack enable pnpm
+      shell: bash
+    - name: Activate pnpm
+      run: corepack prepare "pnpm@${{ inputs.pnpm-version }}" --activate
       shell: bash
     - name: Install dependencies
       run: pnpm install --frozen-lockfile

--- a/.github/actions/pnpm-setup/action.yml
+++ b/.github/actions/pnpm-setup/action.yml
@@ -13,10 +13,9 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
         cache: pnpm
-    - name: Setup pnpm
-      uses: pnpm/action-setup@v4
-      with:
-        run_install: false
+    - name: Enable Corepack
+      run: corepack enable
+      shell: bash
     - name: Install dependencies
       run: pnpm install --frozen-lockfile
       shell: bash

--- a/.github/actions/pnpm-setup/action.yml
+++ b/.github/actions/pnpm-setup/action.yml
@@ -5,18 +5,25 @@ inputs:
     description: Node.js version to use
     default: '22'
     required: false
+  pnpm-version:
+    description: pnpm version to install
+    default: '10.18.1'
+    required: false
 runs:
   using: composite
   steps:
     - name: Checkout repository
       uses: actions/checkout@v5
-    - name: Setup pnpm
-      uses: pnpm/action-setup@v4
     - name: Setup Node.js
       uses: actions/setup-node@v5
       with:
         node-version: ${{ inputs.node-version }}
         cache: pnpm
+    - name: Setup pnpm
+      uses: pnpm/action-setup@v4
+      with:
+        version: ${{ inputs.pnpm-version }}
+        run_install: false
     - name: Install dependencies
       run: pnpm install --frozen-lockfile
       shell: bash

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,5 +6,6 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/pnpm-setup
       - run: pnpm run lint

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,10 +1,10 @@
-name: Lint
+name: Unit Tests
 
 on: [push, pull_request]
 
 jobs:
-  lint:
+  unit-tests:
     runs-on: ubuntu-latest
     steps:
       - uses: ./.github/actions/pnpm-setup
-      - run: pnpm run lint
+      - run: pnpm run test:unit

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -6,5 +6,6 @@ jobs:
   unit-tests:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/pnpm-setup
       - run: pnpm run test:unit


### PR DESCRIPTION
## Summary
- add a reusable composite action to install dependencies with pnpm
- update the lint workflow to use the shared setup action
- create a Unit Tests workflow that runs `pnpm run test:unit`

## Testing
- pnpm run test:unit
- pnpm run test:browser *(fails: Missing script: test:browser)*
- pnpm run lint *(fails: GET https://registry.npmjs.org/@eslint-react%2Feslint-plugin: Forbidden - 403)*
- pnpm run lint:types


------
https://chatgpt.com/codex/tasks/task_b_68e8feb36d388332854b6bcaed47a2b0