### PR TITLE
Add #test alias for unit tests

### DIFF
--- a/tests/unit/setup/each.tsx
+++ b/tests/unit/setup/each.tsx
@@ -4,8 +4,8 @@ import { cleanup, render, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach  } from 'vitest';
 
 import Editor from '@/editor/Editor';
-import { lexicalMutate, lexicalValidate } from '../utils/lexical-helpers';
-import LexicalTestBridge from '../utils/LexicalTestBridge';
+import { lexicalMutate, lexicalValidate } from '#test/utils/lexical-helpers';
+import LexicalTestBridge from '#test/utils/LexicalTestBridge';
 
 beforeEach<TestContext>(async (ctx) => {
   let editor: LexicalEditor | null = null;

--- a/tests/unit/setup/each.tsx
+++ b/tests/unit/setup/each.tsx
@@ -1,11 +1,10 @@
 import type { LexicalEditor } from 'lexical';
-import type {TestContext} from 'vitest';
-import { cleanup, render, waitFor } from '@testing-library/react';
-import { afterEach, beforeEach  } from 'vitest';
-
-import Editor from '@/editor/Editor';
+import type { TestContext } from 'vitest';
 import { lexicalMutate, lexicalValidate } from '#test/utils/lexical-helpers';
 import LexicalTestBridge from '#test/utils/LexicalTestBridge';
+import { cleanup, render, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach } from 'vitest';
+import Editor from '@/editor/Editor';
 
 beforeEach<TestContext>(async (ctx) => {
   let editor: LexicalEditor | null = null;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,9 @@
       "@/*": [
         "./src/*"
       ],
+      "#test/*": [
+        "./tests/unit/*"
+      ],
       "#env": [
         "./config/env.server.ts"
       ]

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -28,6 +28,7 @@ export default defineConfig(() => {
     resolve: {
       alias: {
         "@": "/src",
+        "#test": path.resolve(__dirname, "./tests/unit"),
         "#env": path.resolve(__dirname, "./config/env.server.ts"),
       },
     },


### PR DESCRIPTION
## Summary
- add a #test module alias in the TypeScript and Vite configurations pointing to the unit test directory
- update the unit test setup imports to rely on the new alias instead of relative parent paths

## Testing
- pnpm test:unit

------
https://chatgpt.com/codex/tasks/task_b_68eab00bcd0c83329bc4c1bcef02b99a