### PR TITLE
test: expose lexical helpers via ctx.lexical

### DIFF
--- a/tests/unit/root-schema.spec.tsx
+++ b/tests/unit/root-schema.spec.tsx
@@ -9,20 +9,22 @@ import {
 import { $createParagraphNode, $createTextNode, $getRoot } from 'lexical';
 import { expect, it } from 'vitest';
 
-it('clear', async ({ lexicalMutate, lexicalValidate }) => {
-  await lexicalMutate(() => {
+it('clear', async ({ lexical }) => {
+  await lexical.mutate(() => {
     $getRoot().clear();
   });
 
-  lexicalValidate(() => {
+  lexical.validate(() => {
     const list = expectSingleListRoot();
     expect(list.getListType()).toBe('bullet');
     expectListItemCount(list, 1); // placeholder paragraph
   });
 });
 
-it('normalizes root after list command dispatch', async ({ editor, lexicalMutate, lexicalValidate }) => {
-  await lexicalMutate(() => {
+it('normalizes root after list command dispatch', async ({ lexical }) => {
+  const { editor, mutate, validate } = lexical;
+
+  await mutate(() => {
     const root = $getRoot();
     root.clear();
 
@@ -36,17 +38,17 @@ it('normalizes root after list command dispatch', async ({ editor, lexicalMutate
   });
 
   editor.dispatchCommand(INSERT_UNORDERED_LIST_COMMAND, undefined);
-  await lexicalMutate(() => { });
+  await mutate(() => { });
 
-  lexicalValidate(() => {
+  validate(() => {
     const list = expectSingleListRoot();
     expect(list.getListType()).toBe('bullet');
     expectListItems(list, ['First', 'Second']);
   });
 });
 
-it('allows ordered list as the root list type when present', async ({ lexicalMutate, lexicalValidate }) => {
-  await lexicalMutate(() => {
+it('allows ordered list as the root list type when present', async ({ lexical }) => {
+  await lexical.mutate(() => {
     const root = $getRoot();
     root.clear();
 
@@ -57,15 +59,15 @@ it('allows ordered list as the root list type when present', async ({ lexicalMut
     root.append(list);
   });
 
-  lexicalValidate(() => {
+  lexical.validate(() => {
     const list = expectSingleListRoot();
     expect(list.getListType()).toBe('number');
     expectListItems(list, ['ordered']);
   });
 });
 
-it('wraps non-list root children into list items', async ({ lexicalMutate, lexicalValidate }) => {
-  await lexicalMutate(() => {
+it('wraps non-list root children into list items', async ({ lexical }) => {
+  await lexical.mutate(() => {
     const root = $getRoot();
     root.clear();
 
@@ -77,15 +79,15 @@ it('wraps non-list root children into list items', async ({ lexicalMutate, lexic
     root.append(firstParagraph, secondParagraph);
   });
 
-  lexicalValidate(() => {
+  lexical.validate(() => {
     const list = expectSingleListRoot();
     expect(list.getListType()).toBe('bullet');
     expectListItems(list, ['alpha', 'beta']);
   });
 });
 
-it('merges multiple bullet lists under a single root list', async ({ lexicalMutate, lexicalValidate }) => {
-  await lexicalMutate(() => {
+it('merges multiple bullet lists under a single root list', async ({ lexical }) => {
+  await lexical.mutate(() => {
     const root = $getRoot();
     root.clear();
 
@@ -102,18 +104,18 @@ it('merges multiple bullet lists under a single root list', async ({ lexicalMuta
     root.append(firstList, secondList);
   });
 
-  lexicalValidate(() => {
+  lexical.validate(() => {
     const list = expectSingleListRoot();
     expect(list.getListType()).toBe('bullet');
     expectListItems(list, ['one', 'two']);
   });
 });
 
-it('leaves a canonical single list untouched', async ({ lexicalMutate, lexicalValidate }) => {
+it('leaves a canonical single list untouched', async ({ lexical }) => {
   let originalListKey: string;
   let originalItemKeys: string[] = [];
 
-  await lexicalMutate(() => {
+  await lexical.mutate(() => {
     const root = $getRoot();
     root.clear();
 
@@ -130,7 +132,7 @@ it('leaves a canonical single list untouched', async ({ lexicalMutate, lexicalVa
     originalItemKeys = list.getChildren().map((child) => child.getKey());
   });
 
-  lexicalValidate(() => {
+  lexical.validate(() => {
     const list = expectSingleListRoot();
     expect(list.getKey()).toBe(originalListKey);
     const items = list.getChildren();

--- a/tests/unit/setup/each.tsx
+++ b/tests/unit/setup/each.tsx
@@ -1,4 +1,4 @@
-import type { LexicalEditor } from 'lexical';
+import type { EditorUpdateOptions, LexicalEditor } from 'lexical';
 import type { TestContext } from 'vitest';
 import { lexicalMutate, lexicalValidate } from '#test/utils/lexical-helpers';
 import LexicalTestBridge from '#test/utils/LexicalTestBridge';
@@ -19,9 +19,16 @@ beforeEach<TestContext>(async (ctx) => {
     if (!editor) throw new Error('Lexical editor not initialized in time');
   });
 
-  ctx.lexicalMutate = (fn, opts) => lexicalMutate(editor!, fn, opts);
-  ctx.lexicalValidate = <T,>(fn: () => T) => lexicalValidate(editor!, fn);
-  ctx.editor = editor!;
+  const mutate = (fn: () => void, opts?: EditorUpdateOptions) =>
+    lexicalMutate(editor!, fn, opts);
+  const validate = <T,>(fn: () => T) => lexicalValidate(editor!, fn);
+
+  ctx.lexical = {
+    editor: editor!,
+    mutate,
+    validate,
+  };
+
 });
 
 afterEach(() => {

--- a/tests/unit/setup/vitest.d.ts
+++ b/tests/unit/setup/vitest.d.ts
@@ -1,12 +1,16 @@
 import type { EditorUpdateOptions, LexicalEditor } from 'lexical';
 
 declare module 'vitest' {
-  export interface TestContext {
-    lexicalMutate: (
+  interface LexicalTestHelpers {
+    editor: LexicalEditor;
+    mutate: (
       fn: () => void,
       opts?: EditorUpdateOptions
     ) => Promise<void>;
-    lexicalValidate: <T>(fn: () => T) => T;
-    editor: LexicalEditor;
+    validate: <T>(fn: () => T) => T;
+  }
+
+  export interface TestContext {
+    lexical: LexicalTestHelpers;
   }
 }

--- a/tests/unit/smoke.spec.tsx
+++ b/tests/unit/smoke.spec.tsx
@@ -21,18 +21,18 @@ it('editor', async () => {
   expect(editor).toBeTruthy()
 })
 
-it('lexical helpers', async ({ lexicalMutate, lexicalValidate }) => {
-  await lexicalMutate(() => {
+it('lexical helpers', async ({ lexical }) => {
+  await lexical.mutate(() => {
     $getRoot().clear();
   });
 
-  lexicalValidate(() => {
+  lexical.validate(() => {
     expect($getRoot().getTextContent()).toBe('');
   });
 });
 
-it('debug preview', async ({ lexicalMutate}) => {
-  await lexicalMutate(() => {
+it('debug preview', async ({ lexical }) => {
+  await lexical.mutate(() => {
     const root = $getRoot();
     const paragraph = $createParagraphNode();
     paragraph.append($createTextNode('Vitest Preview in action'));

--- a/tests/unit/utils/lexical-helpers.ts
+++ b/tests/unit/utils/lexical-helpers.ts
@@ -5,6 +5,12 @@ export async function lexicalMutate(
   fn: () => void,
   opts: EditorUpdateOptions = {}
 ): Promise<void> {
+  if (fn.constructor.name === 'AsyncFunction') {
+    throw new TypeError(
+      'lexicalMutate does not support async callbacks. Prepare any async work before calling lexicalMutate.'
+    );
+  }
+
   const timeoutMs = 1500;
   const uniqueTag = `test:${Date.now()}:${Math.random()}`;
   const tags = [uniqueTag, ...([opts.tag ?? []].flat())];


### PR DESCRIPTION
## Summary
- expose the Lexical test helpers under a ctx.lexical namespace
- guard lexical.mutate against async callbacks to preserve synchronous update semantics
- drop temporary lexicalMutate/lexicalValidate shims and update tests to use ctx.lexical.{mutate,validate}

## Testing
- pnpm run lint
- pnpm run test:unit

------
https://chatgpt.com/codex/tasks/task_b_68eac8f0b7e483328ab524a5f7a44ab7