### PR TITLE
Increase collab test server startup wait

### DIFF
--- a/tests/unit/setup/internal/setup-collab-server.ts
+++ b/tests/unit/setup/internal/setup-collab-server.ts
@@ -39,7 +39,7 @@ async function isPortOpen(host: string, port: number): Promise<boolean> {
   });
 }
 
-const MAX_ATTEMPTS = 10;
+const MAX_ATTEMPTS = 50;
 const POLL_INTERVAL = 100;
 
 async function waitForPort(host: string, port: number): Promise<void> {


### PR DESCRIPTION
## Summary
- increase the websocket readiness polling attempts so the collab test server has longer to boot

## Testing
- pnpm exec vitest run tests/unit/collab

------
https://chatgpt.com/codex/tasks/task_e_68fba2ca8e488330b57010745b912ed4