### PR TITLE
Run workflows only on push events

### DIFF
--- a/.github/workflows/collab-tests.yml
+++ b/.github/workflows/collab-tests.yml
@@ -1,6 +1,6 @@
 name: Collaboration Tests
 
-on: [push, pull_request]
+on: push
 
 jobs:
   collab-unit-tests:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 name: Lint
 
-on: [push, pull_request]
+on: push
 
 jobs:
   typecheck:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,6 +1,6 @@
 name: Unit Tests
 
-on: [push, pull_request]
+on: push
 
 jobs:
   unit-tests:


### PR DESCRIPTION
## Summary
- trigger the lint, unit test, and collaboration test workflows only on push events to avoid duplicate runs on PRs

## Testing
- pnpm run lint
- pnpm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68fba44d792c83308f1d47c288a80c4f