### PR TITLE
Fix collaboration context import for browser bundles

### DIFF
--- a/src/editor/plugins/collaboration/collaborationContext.ts
+++ b/src/editor/plugins/collaboration/collaborationContext.ts
@@ -1,34 +1,13 @@
-import { createRequire } from 'node:module';
-import { resolve } from 'node:path';
-import process from 'node:process';
-import type { Doc } from 'yjs';
+import { collaborationContext } from 'lexical-vue/dist/shared/useCollaborationContext.js';
+import type { CollaborationContextState } from 'lexical-vue/dist/shared/useCollaborationContext.js';
 
-interface CollaborationContextType {
-  clientID: number;
-  color: string;
-  isCollabActive: boolean;
-  name: string;
-  yjsDocMap: Map<string, Doc>;
-}
+const contextStack: CollaborationContextState[] = [];
 
-const require = createRequire(import.meta.url);
-const modulePath = resolve(
-  process.cwd(),
-  'node_modules/lexical-vue/dist/shared/useCollaborationContext.js'
-);
-
-const { collaborationContext } = require(modulePath) as {
-  collaborationContext: { value: CollaborationContextType };
-};
-
-const contextStack: CollaborationContextType[] = [];
-
-function cloneContext(source: CollaborationContextType): CollaborationContextType {
+function cloneContext(source: CollaborationContextState): CollaborationContextState {
   return {
+    ...source,
     clientID: 0,
-    color: source.color,
     isCollabActive: false,
-    name: source.name,
     yjsDocMap: new Map(),
   };
 }

--- a/src/types/lexical-vue.d.ts
+++ b/src/types/lexical-vue.d.ts
@@ -1,0 +1,15 @@
+declare module 'lexical-vue/dist/shared/useCollaborationContext.js' {
+  import type { Doc } from 'yjs';
+
+  export interface CollaborationContextState {
+    clientID: number;
+    color: string;
+    isCollabActive: boolean;
+    name: string;
+    yjsDocMap: Map<string, Doc>;
+  }
+
+  export const collaborationContext: {
+    value: CollaborationContextState;
+  };
+}

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -39,6 +39,10 @@ export default defineConfig(() => {
         "#tests": path.resolve(__dirname, "./tests/unit/_support/lib/index.ts"),
         "#fixtures": path.resolve(__dirname, "./tests/fixtures"),
         "#config": path.resolve(__dirname, "./config"),
+        "lexical-vue/dist/shared/useCollaborationContext.js": path.resolve(
+          __dirname,
+          "./node_modules/lexical-vue/dist/shared/useCollaborationContext.js"
+        ),
       },
     },
     test: {


### PR DESCRIPTION
## Summary
- replace the Node-only require with a browser-friendly lexical-vue collaboration context import
- add a Vite alias and ambient typings so the deep module can be resolved during builds

## Testing
- pnpm run lint
- pnpm run test:unit
- pnpm run test:unit:collab

------
https://chatgpt.com/codex/tasks/task_e_68ff9045166c8330b1c1bbf6d18a2179