### PR TITLE
Refactor collaboration runtime to use Yjs v2 binding

### DIFF
--- a/src/editor/plugins/collaboration/CollaborationProvider.tsx
+++ b/src/editor/plugins/collaboration/CollaborationProvider.tsx
@@ -1,13 +1,13 @@
 import type { ReactNode } from 'react';
 import { env } from '#config/env-client';
 import { createContext, use, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import type { ProviderFactory } from './collaborationRuntime';
-import { CollaborationSyncController, createProviderFactory } from './collaborationRuntime';
+import type { CollaborationSessionFactory } from './collaborationRuntime';
+import { CollaborationSyncController, createSessionFactory } from './collaborationRuntime';
 
 interface CollaborationStatusValue {
   ready: boolean;
   enabled: boolean;
-  providerFactory: ProviderFactory;
+  sessionFactory: CollaborationSessionFactory;
   hasUnsyncedChanges: boolean;
   waitForSync: () => Promise<void>;
 }
@@ -67,8 +67,8 @@ function useCollaborationRuntimeValue(): CollaborationStatusValue {
     }
   }, [enabled, syncController]);
 
-  const providerFactory = useMemo(
-    () => createProviderFactory({ setReady, syncController }, endpoint),
+  const sessionFactory = useMemo(
+    () => createSessionFactory({ setReady, syncController }, endpoint),
     [endpoint, setReady, syncController]
   );
 
@@ -105,11 +105,11 @@ function useCollaborationRuntimeValue(): CollaborationStatusValue {
     () => ({
       ready: resolvedReady,
       enabled,
-      providerFactory,
+      sessionFactory,
       hasUnsyncedChanges,
       waitForSync,
     }),
-    [enabled, hasUnsyncedChanges, providerFactory, resolvedReady, waitForSync]
+    [enabled, hasUnsyncedChanges, resolvedReady, sessionFactory, waitForSync]
   );
 }
 

--- a/tests/unit/_support/setup/_internal/assertions/console.ts
+++ b/tests/unit/_support/setup/_internal/assertions/console.ts
@@ -10,9 +10,14 @@ const consoleSpies = LEVELS.map((level) => {
 
 afterEach(() => {
   for (const { level, spy } of consoleSpies) {
-    const hasAllowListedMessage = (arg: unknown) =>
-      typeof arg === 'string' &&
-      arg.includes('Invalid access: Add Yjs type to a document before reading data.');
+    const hasAllowListedMessage = (arg: unknown) => {
+      if (typeof arg !== 'string') {
+        return false;
+      }
+
+      // arg.includes('Invalid access: Add Yjs type to a document before reading data.');
+      return false;
+    };
 
     const relevantCalls = spy.mock.calls.filter((args) => !args.some(hasAllowListedMessage));
 


### PR DESCRIPTION
## Summary
- swap the collaboration plugin over to Lexical's experimental v2 Yjs binding and manage the provider lifecycle in React
- expose a collaboration session factory from the provider/runtime so docs and providers are initialised with the v2 root
- keep the console warning assertion strict by leaving the old allowlist disabled while ensuring non-string args are ignored

## Testing
- pnpm run test:unit:collab
- pnpm run lint

------
https://chatgpt.com/codex/tasks/task_e_690333c00db0833097babadc8484f676