### PR TITLE
Fix Yjs warnings by pre-initializing docs and adopting collaboration v2

### DIFF
--- a/src/editor/plugins/collaboration/CollaborationPlugin.tsx
+++ b/src/editor/plugins/collaboration/CollaborationPlugin.tsx
@@ -1,8 +1,15 @@
 import type { ReactNode } from 'react';
-import { LexicalCollaboration } from '@lexical/react/LexicalCollaborationContext';
-import { CollaborationPlugin as LexicalCollaborationPlugin } from '@lexical/react/LexicalCollaborationPlugin';
+import { useEffect, useState } from 'react';
+import {
+  LexicalCollaboration,
+  useCollaborationContext as useLexicalCollaborationContext,
+} from '@lexical/react/LexicalCollaborationContext';
+import { CollaborationPluginV2__EXPERIMENTAL } from '@lexical/react/LexicalCollaborationPlugin';
 import { HistoryPlugin } from '@lexical/react/LexicalHistoryPlugin';
+import type { Provider } from '@lexical/yjs';
+import type * as Y from 'yjs';
 import { CollaborationProvider, useCollaborationStatus } from './CollaborationProvider';
+import type { ProviderFactory } from './collaborationRuntime';
 
 const DEFAULT_ROOM_ID = 'main';
 
@@ -24,7 +31,44 @@ function CollaborationRuntimePlugin() {
 
   return (
     <LexicalCollaboration>
-      <LexicalCollaborationPlugin id={DEFAULT_ROOM_ID} providerFactory={providerFactory} shouldBootstrap />
+      <CollaborationRuntimeBridge providerFactory={providerFactory} />
     </LexicalCollaboration>
+  );
+}
+
+interface CollaborationRuntimeBridgeProps {
+  providerFactory: ProviderFactory;
+}
+
+function CollaborationRuntimeBridge({ providerFactory }: CollaborationRuntimeBridgeProps) {
+  const { yjsDocMap } = useLexicalCollaborationContext();
+  const [provider, setProvider] = useState<Provider | null>(null);
+  const [doc, setDoc] = useState<Y.Doc | null>(null);
+
+  useEffect(() => {
+    const nextProvider = providerFactory(DEFAULT_ROOM_ID, yjsDocMap);
+    // eslint-disable-next-line react-hooks-extra/no-direct-set-state-in-use-effect -- Provider lifecycle is orchestrated by this effect so the async factory only runs when dependencies change.
+    setProvider((current) => (current === nextProvider ? current : nextProvider));
+
+    const nextDoc = yjsDocMap.get(DEFAULT_ROOM_ID) ?? null;
+    // eslint-disable-next-line react-hooks-extra/no-direct-set-state-in-use-effect -- Provider lifecycle is orchestrated by this effect so the async factory only runs when dependencies change.
+    setDoc((current) => (current === nextDoc ? current : nextDoc));
+
+    return () => {
+      nextProvider.disconnect();
+    };
+  }, [providerFactory, yjsDocMap]);
+
+  if (provider == null || doc == null) {
+    return null;
+  }
+
+  return (
+    <CollaborationPluginV2__EXPERIMENTAL
+      id={DEFAULT_ROOM_ID}
+      provider={provider}
+      doc={doc}
+      __shouldBootstrapUnsafe
+    />
   );
 }

--- a/src/editor/plugins/collaboration/collaborationRuntime.ts
+++ b/src/editor/plugins/collaboration/collaborationRuntime.ts
@@ -47,6 +47,11 @@ export function createProviderFactory(
       docMap.set(id, doc);
     }
 
+    // Ensure the shared root exists before the provider starts syncing. Yjs warns when
+    // collaborative types are accessed prior to being attached to a document, and
+    // Lexical expects the `root` XmlText to always be present.
+    doc.get('root', Y.XmlText);
+
     const provider = new WebsocketProvider(endpoint, id, doc, {
       connect: false,
     });

--- a/tests/unit/_support/setup/_internal/assertions/console.ts
+++ b/tests/unit/_support/setup/_internal/assertions/console.ts
@@ -10,12 +10,7 @@ const consoleSpies = LEVELS.map((level) => {
 
 afterEach(() => {
   for (const { level, spy } of consoleSpies) {
-    const hasAllowListedMessage = (arg: unknown) =>
-      typeof arg === 'string' &&
-      // arg.includes('Invalid access: Add Yjs type to a document before reading data.');
-      false;
-
-    const relevantCalls = spy.mock.calls.filter((args) => !args.some(hasAllowListedMessage));
+    const relevantCalls = spy.mock.calls;
 
     if (relevantCalls.length > 0) {
       const argsPreview = relevantCalls

--- a/tests/unit/_support/setup/_internal/assertions/console.ts
+++ b/tests/unit/_support/setup/_internal/assertions/console.ts
@@ -4,7 +4,7 @@ const LEVELS = ['error', 'warn'] as const;
 
 const consoleSpies = LEVELS.map((level) => {
   // swallow console noise while recording calls
-  const spy = vi.spyOn(console, level).mockImplementation(() => { });
+  const spy = vi.spyOn(console, level).mockImplementation(() => {});
   return { level, spy };
 });
 
@@ -12,7 +12,8 @@ afterEach(() => {
   for (const { level, spy } of consoleSpies) {
     const hasAllowListedMessage = (arg: unknown) =>
       typeof arg === 'string' &&
-      arg.includes('Invalid access: Add Yjs type to a document before reading data.');
+      // arg.includes('Invalid access: Add Yjs type to a document before reading data.');
+      false;
 
     const relevantCalls = spy.mock.calls.filter((args) => !args.some(hasAllowListedMessage));
 


### PR DESCRIPTION
## Summary
- remove the console allowlist so Yjs warnings surface in tests
- initialize the shared Yjs root before wiring the websocket provider to stop premature access warnings
- switch the collaboration runtime to Lexical's v2 binding with an explicit provider bridge

## Testing
- pnpm run test:unit:collab
- pnpm run lint

------
https://chatgpt.com/codex/tasks/task_e_6903338006c08330ae1b201a5f394780