### PR TITLE
Simplify collaboration runtime and remove console allowlist

### DIFF
--- a/src/editor/plugins/collaboration/CollaborationProvider.tsx
+++ b/src/editor/plugins/collaboration/CollaborationProvider.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react';
 import { env } from '#config/env-client';
 import { createContext, use, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { ProviderFactory } from './collaborationRuntime';
-import { CollaborationSyncController, createProviderFactory } from './collaborationRuntime';
+import { createProviderFactory } from './collaborationRuntime';
 
 interface CollaborationStatusValue {
   ready: boolean;
@@ -43,10 +43,6 @@ function useCollaborationRuntimeValue(): CollaborationStatusValue {
     return `${wsProtocol}://${hostname}:${env.collabPort}`;
   }, []);
 
-  const syncController = useMemo(
-    () => new CollaborationSyncController(setUnsynced, enabled),
-    [enabled, setUnsynced]
-  );
   const waitersRef = useRef<Set<() => void>>(new Set());
 
   const flushWaiters = useCallback(() => {
@@ -61,15 +57,9 @@ function useCollaborationRuntimeValue(): CollaborationStatusValue {
     }
   }, []);
 
-  useEffect(() => {
-    if (!enabled) {
-      syncController.setUnsynced(false);
-    }
-  }, [enabled, syncController]);
-
   const providerFactory = useMemo(
-    () => createProviderFactory({ setReady, syncController }, endpoint),
-    [endpoint, setReady, syncController]
+    () => createProviderFactory({ setReady, setUnsynced }, endpoint),
+    [endpoint, setReady, setUnsynced]
   );
 
   const resolvedReady = !enabled || ready;

--- a/tests/unit/_support/setup/_internal/assertions/console.ts
+++ b/tests/unit/_support/setup/_internal/assertions/console.ts
@@ -10,15 +10,8 @@ const consoleSpies = LEVELS.map((level) => {
 
 afterEach(() => {
   for (const { level, spy } of consoleSpies) {
-    const hasAllowListedMessage = (arg: unknown) =>
-      typeof arg === 'string' &&
-      // arg.includes('Invalid access: Add Yjs type to a document before reading data.');
-      false;
-
-    const relevantCalls = spy.mock.calls.filter((args) => !args.some(hasAllowListedMessage));
-
-    if (relevantCalls.length > 0) {
-      const argsPreview = relevantCalls
+    if (spy.mock.calls.length > 0) {
+      const argsPreview = spy.mock.calls
         .map((args) => args.map((arg) => String(arg)).join(' '))
         .join('\n');
       spy.mockClear();


### PR DESCRIPTION
## Summary
- remove the console warning allowlist so tests fail on any unexpected console noise
- simplify the collaboration provider to rely on the streamlined provider factory
- streamline the collaboration runtime, keeping readiness and unsynced tracking without the custom controller

## Testing
- pnpm run test:unit:collab
- pnpm run lint
- pnpm run typecheck
- pnpm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_6903448bc5648330bd10c874e8774ead