### PR TITLE
Clean up collaboration listeners between tests

### DIFF
--- a/src/editor/plugins/collaboration/CollaborationPlugin.tsx
+++ b/src/editor/plugins/collaboration/CollaborationPlugin.tsx
@@ -51,7 +51,7 @@ function CollaborationRuntimeBridge({ providerFactory }: CollaborationRuntimeBri
 
     return () => {
       providerRef.current = null;
-      nextProvider.disconnect();
+      nextProvider.destroy();
     };
   }, [providerFactory, yjsDocMap]);
 

--- a/tests/unit/_support/setup/_internal/lexical/state.ts
+++ b/tests/unit/_support/setup/_internal/lexical/state.ts
@@ -109,16 +109,11 @@ export function createLexicalTestHelpers(
         return;
       }
 
-      await collab.waitForSync();
-
-      await new Promise((resolve) => {
-        setTimeout(resolve, 0);
-      });
-
-      const next = getCollabStatus();
-      if (!next?.enabled || (!next.hasUnsyncedChanges && next.ready)) {
+      if (!collab.hasUnsyncedChanges && collab.ready) {
         return;
       }
+
+      await collab.waitForSync();
     }
   }
 

--- a/tests/unit/_support/setup/index.ts
+++ b/tests/unit/_support/setup/index.ts
@@ -1,9 +1,4 @@
-import process from 'node:process';
 import '@testing-library/jest-dom/vitest';
 import './_internal/assertions';
 import './_internal/env';
 import './_internal/lexical';
-
-if (typeof process.setMaxListeners === 'function') {
-  process.setMaxListeners(0);
-}


### PR DESCRIPTION
## Summary
- remove the test harness override that raised process listener limits
- ensure collaboration providers destroy websocket providers so listeners are removed
- tighten the collaboration test helper to wait for sync without timeouts

## Testing
- pnpm run test:unit:collab
- pnpm run lint

------
https://chatgpt.com/codex/tasks/task_e_6903be1925288330801790821f6841b9