### PR TITLE
Add Lexical ESLint plugin and align helper names

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -21,7 +21,7 @@ access through the new module.
 3. `$indentNote`/`$outdentNote` return booleans and throw generic `Error`s,
    whereas Lexical silently no-ops or raises formatted dev invariants; the
    reporting style is inconsistent.
-4. `getOrCreateChildList` omits copying text format and style from the source
+4. `$getOrCreateChildList` omits copying text format and style from the source
    list/item, unlike Lexical, so new wrappers lose typography.
 5. The helpers attempt to auto-heal malformed wrappers by removing them instead
    of surfacing invariants like Lexical does.

--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -1,4 +1,5 @@
 import antfu from '@antfu/eslint-config';
+import lexicalPlugin from '@lexical/eslint-plugin';
 
 export default antfu(
   {
@@ -89,6 +90,14 @@ export default antfu(
           message: 'preview() is for local debugging only; remove preview() calls before committing.',
         },
       ],
+    },
+  },
+  {
+    plugins: {
+      '@lexical': lexicalPlugin,
+    },
+    rules: {
+      '@lexical/rules-of-lexical': 'error',
     },
   },
 );

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "devDependencies": {
     "@antfu/eslint-config": "^5.4.1",
     "@eslint-react/eslint-plugin": "^1.53.1",
+    "@lexical/eslint-plugin": "^0.38.2",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       '@eslint-react/eslint-plugin':
         specifier: ^1.53.1
         version: 1.53.1(eslint@9.38.0(jiti@2.6.1))(ts-api-utils@2.1.0(typescript@5.9.3))(typescript@5.9.3)
+      '@lexical/eslint-plugin':
+        specifier: ^0.38.2
+        version: 0.38.2(eslint@9.38.0(jiti@2.6.1))
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
@@ -772,6 +775,11 @@ packages:
 
   '@lexical/dragon@0.37.0':
     resolution: {integrity: sha512-iC4OKivEPtt7cGVSwZylLfz5T7Oqr9q9EOosS6E/byMyoqwkYWGjXn/qFiwIv1Xo3+G19vhfChi/+ZcYLXpHPw==}
+
+  '@lexical/eslint-plugin@0.38.2':
+    resolution: {integrity: sha512-T/en3lJBEU1ajLQve21L721hKzAtewEnGwFSmhq4fwGcqsey5UYvyHMIyn0wKcAh6fvWTRzQDLqxr7Ow4lwnrQ==}
+    peerDependencies:
+      eslint: '>=7.31.0 || ^8.0.0'
 
   '@lexical/extension@0.37.0':
     resolution: {integrity: sha512-Z58f2tIdz9bn8gltUu5cVg37qROGha38dUZv20gI2GeNugXAkoPzJYEcxlI1D/26tkevJ/7VaFUr9PTk+iKmaA==}
@@ -4440,6 +4448,10 @@ snapshots:
     dependencies:
       '@lexical/extension': 0.37.0
       lexical: 0.37.0
+
+  '@lexical/eslint-plugin@0.38.2(eslint@9.38.0(jiti@2.6.1))':
+    dependencies:
+      eslint: 9.38.0(jiti@2.6.1)
 
   '@lexical/extension@0.37.0':
     dependencies:

--- a/src/editor/lexical-helpers.ts
+++ b/src/editor/lexical-helpers.ts
@@ -39,12 +39,12 @@ export function $indentNote(noteItem: ListItemNode): boolean {
     return false;
   }
 
-  const targetList = getOrCreateChildList(previousContent, parentList);
+  const targetList = $getOrCreateChildList(previousContent, parentList);
   targetList.append(...getNodesToMove(noteItem));
   return true;
 }
 
-function getOrCreateChildList(parentContentItem: ListItemNode, parentList: ListNode): ListNode {
+function $getOrCreateChildList(parentContentItem: ListItemNode, parentList: ListNode): ListNode {
   const existingWrapper = parentContentItem.getNextSibling();
   if (isChildrenWrapper(existingWrapper)) {
     const childList = existingWrapper.getFirstChild();

--- a/tests/unit/root-schema.spec.tsx
+++ b/tests/unit/root-schema.spec.tsx
@@ -1,4 +1,4 @@
-import type { ListNode } from '@lexical/list';
+import type { ListItemNode, ListNode } from '@lexical/list';
 import {
   $createListItemNode,
   $createListNode,
@@ -15,7 +15,7 @@ it('clear', async ({ lexical }) => {
   });
 
   lexical.validate(() => {
-    const list = expectSingleListRoot();
+    const list = $expectSingleListRoot();
     expect(list.getListType()).toBe('bullet');
     expectListItemCount(list, 1); // placeholder paragraph
   });
@@ -41,7 +41,7 @@ it('normalizes root after list command dispatch', async ({ lexical }) => {
   await mutate(() => { });
 
   validate(() => {
-    const list = expectSingleListRoot();
+    const list = $expectSingleListRoot();
     expect(list.getListType()).toBe('bullet');
     expectListItems(list, ['First', 'Second']);
   });
@@ -60,7 +60,7 @@ it('allows ordered list as the root list type when present', async ({ lexical })
   });
 
   lexical.validate(() => {
-    const list = expectSingleListRoot();
+    const list = $expectSingleListRoot();
     expect(list.getListType()).toBe('number');
     expectListItems(list, ['ordered']);
   });
@@ -80,7 +80,7 @@ it('wraps non-list root children into list items', async ({ lexical }) => {
   });
 
   lexical.validate(() => {
-    const list = expectSingleListRoot();
+    const list = $expectSingleListRoot();
     expect(list.getListType()).toBe('bullet');
     expectListItems(list, ['alpha', 'beta']);
   });
@@ -105,7 +105,7 @@ it('merges multiple bullet lists under a single root list', async ({ lexical }) 
   });
 
   lexical.validate(() => {
-    const list = expectSingleListRoot();
+    const list = $expectSingleListRoot();
     expect(list.getListType()).toBe('bullet');
     expectListItems(list, ['one', 'two']);
   });
@@ -133,14 +133,19 @@ it('leaves a canonical single list untouched', async ({ lexical }) => {
   });
 
   lexical.validate(() => {
-    const list = expectSingleListRoot();
+    const list = $expectSingleListRoot();
     expect(list.getKey()).toBe(originalListKey);
-    const items = list.getChildren();
+    const items = list.getChildren().map((child): ListItemNode => {
+      if (!$isListItemNode(child)) {
+        throw new Error('Expected root list child to remain a list item');
+      }
+      return child;
+    });
     expect(items.map((child) => child.getKey())).toEqual(originalItemKeys);
   });
 });
 
-function expectSingleListRoot(): ListNode {
+function $expectSingleListRoot(): ListNode {
   const root = $getRoot();
   expect(root.getChildrenSize()).toBe(1);
 


### PR DESCRIPTION
## Summary
- add @lexical/eslint-plugin and enable its rules-of-lexical checks
- update indent helpers and tests to follow the $-function convention and adjust docs
- tighten list item assertions in root-schema tests to keep TypeScript happy

## Testing
- pnpm run lint
- pnpm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_6904aacfa5488330adc1d8f759b1a172