### PR TITLE
refactor: trim snapshot cli parsing

### DIFF
--- a/src/editor/plugins/collaboration/CollaborationProvider.tsx
+++ b/src/editor/plugins/collaboration/CollaborationProvider.tsx
@@ -42,9 +42,8 @@ function useCollaborationRuntimeValue(): CollaborationStatusValue {
     if (typeof window === 'undefined') {
       return fallback;
     }
-    const value = new URLSearchParams(window.location.search).get('doc');
-    const trimmed = value?.trim();
-    return trimmed && trimmed.length > 0 ? trimmed : fallback;
+    const doc = new URLSearchParams(window.location.search).get('doc')?.trim();
+    return doc || fallback;
   }, []);
   const [ready, setReady] = useState(!enabled);
   const [syncing, setSyncing] = useState(enabled);


### PR DESCRIPTION
## Summary
- simplify snapshot CLI parsing by sharing flag handling and returning the selected action directly
- tighten collaboration document id lookup to reuse URL query trimming logic inline

## Testing
- pnpm run lint
- pnpm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_690b81117c548330aec413f489f480b9