### PR TITLE
Simplify root list normalization check

### DIFF
--- a/src/editor/plugins/RootSchemaPlugin.tsx
+++ b/src/editor/plugins/RootSchemaPlugin.tsx
@@ -100,12 +100,11 @@ function $needsListNormalization(root: RootNode): boolean {
     return true;
   }
 
-  const ul = first as ListNode;
-  if (ul.getChildrenSize() === 0) {
+  if (first.getChildrenSize() === 0) {
     return true;
   }
 
-  for (const child of ul.getChildren()) {
+  for (const child of first.getChildren()) {
     if (!$isListItemNode(child)) {
       return true;
     }


### PR DESCRIPTION
## Summary
- remove the redundant alias when checking the root list contents
- reuse the existing node reference while verifying children types during normalization

## Testing
- pnpm run lint
- pnpm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_690b991147c083309d45cc5c26d94020