### PR TITLE
Remove unused React import from main entry

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 


### PR DESCRIPTION
## Summary
- remove the unused `React` import from the client entry point since the project uses the modern JSX transform

## Testing
- pnpm run lint
- pnpm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_690b991147c083309d45cc5c26d94020