### PR TITLE
Simplify and clean up codebase

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,16 +11,15 @@ interface HostContext {
   basePort: number;
 }
 
+function getDefaultPort(protocol: string): number {
+  return protocol === 'https:' ? 443 : 80;
+}
+
 function resolveHost(): HostContext | null {
   if (typeof window === 'undefined') return null;
 
   const { protocol, hostname, port } = window.location;
-  const basePort =
-    port && Number(port) > 0
-      ? Number(port)
-      : protocol === 'https:'
-        ? 443
-        : 80;
+  const basePort = port && Number(port) > 0 ? Number(port) : getDefaultPort(protocol);
 
   return { protocol, hostname, basePort };
 }
@@ -29,13 +28,16 @@ function buildUrl(host: HostContext, portOffset: number, path = ''): string {
   return `${host.protocol}//${host.hostname}:${host.basePort + portOffset}${path}`;
 }
 
+function buildLexicalUrl(host: HostContext): string {
+  const wsEndpoint = `ws://${host.hostname}:1234`;
+  return `${host.protocol}//${host.hostname}:3000/?isCollab=true&collabEndpoint=${wsEndpoint}`;
+}
+
 export default function App() {
   const host = resolveHost();
   const previewUrl = host ? buildUrl(host, 3) : '#preview';
   const vitestUrl = host ? buildUrl(host, 2, '/__vitest__/') : '#vitest';
-  const lexicalUrl = host
-    ? `${host.protocol}//${host.hostname}:3000/?isCollab=true&collabEndpoint=ws://${host.hostname}:1234`
-    : '#lexical';
+  const lexicalUrl = host ? buildLexicalUrl(host) : '#lexical';
 
   return (
     <MantineProvider theme={theme} defaultColorScheme="dark">

--- a/src/editor/plugins/DevPlugin.tsx
+++ b/src/editor/plugins/DevPlugin.tsx
@@ -10,13 +10,11 @@ interface DevPluginProps {
 }
 
 export function DevPlugin({ children }: DevPluginProps): ReactElement {
-  return !config.isDev
-    ? <>{children}</>
-    : <>
-      <SchemaValidationPlugin />
-      <TreeViewPlugin />
+  return (
+    <>
+      {config.isDev && <SchemaValidationPlugin />}
+      {config.isDev && <TreeViewPlugin />}
       {children}
-    </>;
+    </>
+  );
 }
-
-export default DevPlugin;

--- a/src/editor/plugins/SchemaValidationPlugin.tsx
+++ b/src/editor/plugins/SchemaValidationPlugin.tsx
@@ -18,5 +18,3 @@ export function SchemaValidationPlugin(): null {
 
   return null;
 }
-
-export default SchemaValidationPlugin;

--- a/src/editor/plugins/TreeViewPlugin.tsx
+++ b/src/editor/plugins/TreeViewPlugin.tsx
@@ -21,5 +21,3 @@ export function TreeViewPlugin() {
     </section>
   );
 }
-
-export default TreeViewPlugin;

--- a/src/editor/plugins/collaboration/CollaborationPlugin.tsx
+++ b/src/editor/plugins/collaboration/CollaborationPlugin.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { useEffect, useReducer } from 'react';
+import { useEffect, useState } from 'react';
 import {
   LexicalCollaboration,
   useCollaborationContext as useLexicalCollaborationContext,
@@ -35,10 +35,7 @@ function CollaborationRuntimePlugin() {
 function CollaborationRuntimeBridge() {
   const { providerFactory, docId } = useCollaborationStatus();
   const { yjsDocMap } = useLexicalCollaborationContext();
-  const [provider, setProvider] = useReducer(
-    (_: ReturnType<ProviderFactory> | null, next: ReturnType<ProviderFactory> | null) => next,
-    null,
-  );
+  const [provider, setProvider] = useState<ReturnType<ProviderFactory> | null>(null);
 
   useEffect(() => {
     const nextProvider = providerFactory(docId, yjsDocMap);

--- a/src/editor/plugins/collaboration/CollaborationProvider.tsx
+++ b/src/editor/plugins/collaboration/CollaborationProvider.tsx
@@ -53,10 +53,7 @@ function useCollaborationRuntimeValue(): CollaborationStatusValue {
     return `${wsProtocol}://${hostname}:${config.COLLAB_CLIENT_PORT}`;
   }, []);
 
-  const syncController = useMemo(
-    () => new CollaborationSyncController(setSyncing),
-    [setSyncing]
-  );
+  const [syncController] = useState(() => new CollaborationSyncController(setSyncing));
   const waitersRef = useRef<Set<() => void>>(new Set());
 
   const flushWaiters = useCallback(() => {


### PR DESCRIPTION
- Replace trivial useReducer with useState in CollaborationPlugin
- Remove dual exports from plugin files (DevPlugin, TreeViewPlugin, SchemaValidationPlugin)
- Extract helper functions in App.tsx to flatten nested ternaries
- Simplify conditional rendering in DevPlugin using && operator
- Replace useMemo with useState for syncController in CollaborationProvider