### PR TITLE
Simplify and remove redundant code

### DIFF
--- a/src/editor/plugins/RootSchemaPlugin.tsx
+++ b/src/editor/plugins/RootSchemaPlugin.tsx
@@ -75,15 +75,9 @@ function $ensureSingleListRoot(root: RootNode) {
 
 function normalizeRootOnce(editor: LexicalEditor) {
   // Run a one-time normalization outside the transform cycle for fresh editors.
-  const needsNormalization = editor.getEditorState().read(() =>
-    $needsListNormalization($getRoot())
-  );
-
-  if (needsNormalization) {
-    editor.update(() => {
-      $ensureSingleListRoot($getRoot());
-    });
-  }
+  editor.update(() => {
+    $ensureSingleListRoot($getRoot());
+  });
 }
 
 /**


### PR DESCRIPTION
The normalizeRootOnce function was checking if normalization is needed before calling $ensureSingleListRoot, but $ensureSingleListRoot already performs this check as its first operation. This removes the duplicate validation logic, simplifying the code while maintaining the same behavior.