### PR TITLE
Add five-minute timeouts to GitHub workflows

### DIFF
--- a/.github/workflows/collab-tests.yml
+++ b/.github/workflows/collab-tests.yml
@@ -4,6 +4,7 @@ on: push
 
 jobs:
   collab-unit-tests:
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,7 @@ on: push
 
 jobs:
   typecheck:
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -5,6 +5,7 @@ on: push
 jobs:
   unit-tests:
     name: Unit Tests
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
## Summary
- set a five minute timeout on the lint, unit test, and collaboration test GitHub Actions jobs

## Testing
- pnpm run lint
- pnpm run test:unit

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691100d4947c833088a34eb0ce53634f)