### PR TITLE
Ensure Vitest preview cache dir exists

### DIFF
--- a/config/vitest/preview-cache.ts
+++ b/config/vitest/preview-cache.ts
@@ -1,4 +1,5 @@
 /* eslint-disable node/no-process-env -- vitest preview forces us to touch process env vars */
+import { mkdirSync } from 'node:fs';
 import { resolve } from 'node:path';
 import process from 'node:process';
 
@@ -7,6 +8,7 @@ import process from 'node:process';
 const previewCacheDir = resolve('data/.vitest-preview');
 
 export function forceVitestPreviewCacheDir(): void {
+  mkdirSync(previewCacheDir, { recursive: true });
   process.env.TMPDIR ||= previewCacheDir;
   process.env.TMP ||= previewCacheDir;
   process.env.TEMP ||= previewCacheDir;


### PR DESCRIPTION
## Summary
- ensure the Vitest preview cache directory is created before overriding the TMP environment variables so preview runs can reuse the cache path without ENOENT errors

## Testing
- pnpm run lint
- pnpm run test:unit
- pnpm run test:unit:collab *(fails: suite hangs while loading `tests/unit/collab/snapshot.collab.spec.ts` because `WebSocket` is not defined, aborted after ~80s)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911ce4607ec83308e209a534b737682)