### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/collab-tests.yml
+++ b/.github/workflows/collab-tests.yml
@@ -1,4 +1,6 @@
 name: Collaboration Tests
+permissions:
+  contents: read
 
 on: push
 


### PR DESCRIPTION
Potential fix for [https://github.com/remdo-project/remdo/security/code-scanning/3](https://github.com/remdo-project/remdo/security/code-scanning/3)

The best way to fix the problem is to explicitly define the `permissions` for the workflow, restricting the GITHUB_TOKEN scope according to the principle of least privilege. To achieve this, add a `permissions:` key at the top level of the workflow file, right after the workflow name (`name: Collaboration Tests`) and before the `on:` block. Unless the workflow requires write permissions, restrict permissions to `contents: read`, which is the minimal required for most read-only operations. If more privileged operations are ever needed, these should be added specifically and minimally.

No changes are required to the jobs or steps themselves—this is a metadata fix at the root of `.github/workflows/collab-tests.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
