### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,4 +1,6 @@
 name: Unit Tests
+permissions:
+  contents: read
 
 on: push
 


### PR DESCRIPTION
Potential fix for [https://github.com/remdo-project/remdo/security/code-scanning/1](https://github.com/remdo-project/remdo/security/code-scanning/1)

The best way to fix this problem is to add an explicit `permissions` block at the root of the workflow file (`.github/workflows/unit-tests.yml`) to limit the default permissions for the `GITHUB_TOKEN`. Since the workflow's jobs only check out code and run tests, setting `contents: read` is sufficient and follows least-privilege best practices. This change involves adding the following key block directly after the workflow `name: Unit Tests` (and before `on:`):  
```yaml
permissions:
  contents: read
```
No additional methods, imports, or changes are needed. The fix is a single YAML block inserted into the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
