### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,6 @@
 name: Lint
+permissions:
+  contents: read
 
 on: push
 


### PR DESCRIPTION
Potential fix for [https://github.com/remdo-project/remdo/security/code-scanning/2](https://github.com/remdo-project/remdo/security/code-scanning/2)

To fix this issue, an explicit `permissions` block needs to be added to the workflow. Since the job is for linting, running only `pnpm` lint/deps commands, it most likely only needs to read repository contents. Thus, setting `permissions: contents: read` at the workflow root is the safest and most future-proof minimal fix. This will apply read-only access to the repository to all jobs unless a specific job overrides it, which is correct for linters/static analysis. The required change is to add the following lines immediately after the workflow name (line 1):

```yaml
permissions:
  contents: read
```

No additional imports or definitions are needed for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
