### PR TITLE
Add selection plugin to normalize multi-note ranges

### DIFF
--- a/src/editor/Editor.tsx
+++ b/src/editor/Editor.tsx
@@ -9,6 +9,7 @@ import { CollaborationPlugin } from './plugins/collaboration';
 import { IndentationPlugin } from './plugins/IndentationPlugin';
 import { DevPlugin } from './plugins/DevPlugin';
 import { RootSchemaPlugin } from './plugins/RootSchemaPlugin';
+import { NoteSelectionPlugin } from './plugins/NoteSelectionPlugin';
 import './Editor.css';
 
 interface EditorProps {
@@ -24,6 +25,7 @@ export default function Editor({ children }: EditorProps) {
           contentEditable={<ContentEditable className="editor-input" />}
           ErrorBoundary={LexicalErrorBoundary}
         />
+        <NoteSelectionPlugin />
         <IndentationPlugin />
         <ListPlugin hasStrictIndent />
         <CollaborationPlugin>

--- a/src/editor/plugins/IndentationPlugin.tsx
+++ b/src/editor/plugins/IndentationPlugin.tsx
@@ -2,7 +2,13 @@ import type { ListItemNode } from '@lexical/list';
 import { $isListItemNode, $isListNode } from '@lexical/list';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
 import type { LexicalNode } from 'lexical';
-import { $getSelection, $isRangeSelection, COMMAND_PRIORITY_LOW, KEY_TAB_COMMAND } from 'lexical';
+import {
+  $getSelection,
+  $isNodeSelection,
+  $isRangeSelection,
+  COMMAND_PRIORITY_LOW,
+  KEY_TAB_COMMAND,
+} from 'lexical';
 import { useEffect } from 'react';
 import { $indentNote, $outdentNote } from '../lexical-helpers';
 
@@ -98,13 +104,13 @@ export function IndentationPlugin() {
       KEY_TAB_COMMAND,
       (event: KeyboardEvent) => {
         const selection = $getSelection();
+        let selectionNodes: LexicalNode[];
 
-        // Only handle range selections (both collapsed and non-collapsed)
-        if (!$isRangeSelection(selection)) {
+        if ($isRangeSelection(selection) || $isNodeSelection(selection)) {
+          selectionNodes = selection.getNodes();
+        } else {
           return false;
         }
-
-        const selectionNodes = selection.getNodes();
         const listItems: ListItemNode[] = [];
         const seen = new Set<string>();
 

--- a/src/editor/plugins/NoteSelectionPlugin.tsx
+++ b/src/editor/plugins/NoteSelectionPlugin.tsx
@@ -1,0 +1,218 @@
+import type { ListItemNode } from '@lexical/list';
+import { $isListItemNode, $isListNode } from '@lexical/list';
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
+import { useEffect } from 'react';
+import { $createNodeSelection, $getSelection, $isNodeSelection, $isRangeSelection, $setSelection } from 'lexical';
+import type { LexicalNode } from 'lexical';
+
+function isChildrenWrapper(node: ListItemNode): boolean {
+  if (!$isListItemNode(node)) {
+    return false;
+  }
+  const children = node.getChildren();
+  return children.length === 1 && $isListNode(children[0]);
+}
+
+function isNoteContentItem(node: ListItemNode): boolean {
+  return node
+    .getChildren()
+    .some((child) => typeof child.getType === 'function' && child.getType() !== 'list');
+}
+
+function findNearestContentItem(node: LexicalNode | null): ListItemNode | null {
+  let current: LexicalNode | null = node;
+
+  while (current) {
+    if ($isListItemNode(current)) {
+      if (isNoteContentItem(current)) {
+        return current;
+      }
+    }
+    current = current.getParent();
+  }
+
+  return null;
+}
+
+function getChildWrapper(note: ListItemNode): ListItemNode | null {
+  const nextSibling = note.getNextSibling();
+  return $isListItemNode(nextSibling) && isChildrenWrapper(nextSibling) ? nextSibling : null;
+}
+
+function getParentNote(note: ListItemNode): ListItemNode | null {
+  const parentList = note.getParent();
+  if (!$isListNode(parentList)) {
+    return null;
+  }
+
+  const wrapper = parentList.getParent();
+  if (!$isListItemNode(wrapper)) {
+    return null;
+  }
+
+  const possibleParent = wrapper.getPreviousSibling();
+  if ($isListItemNode(possibleParent) && isNoteContentItem(possibleParent)) {
+    return possibleParent;
+  }
+
+  return null;
+}
+
+function isDescendantOf(note: ListItemNode, maybeAncestor: ListItemNode): boolean {
+  let current: ListItemNode | null = getParentNote(note);
+  while (current) {
+    if (current.is(maybeAncestor)) {
+      return true;
+    }
+    current = getParentNote(current);
+  }
+  return false;
+}
+
+function collectContentNotesFromSelection(nodes: LexicalNode[]): ListItemNode[] {
+  const byKey = new Map<string, ListItemNode>();
+  for (const node of nodes) {
+    const note = findNearestContentItem(node);
+    if (!note) {
+      continue;
+    }
+    byKey.set(note.getKey(), note);
+  }
+  return Array.from(byKey.values());
+}
+
+function collectSubtree(note: ListItemNode, acc: Map<string, ListItemNode>): void {
+  const key = note.getKey();
+  if (!acc.has(key)) {
+    acc.set(key, note);
+  }
+
+  const wrapper = getChildWrapper(note);
+  if (!wrapper) {
+    return;
+  }
+
+  const wrapperKey = wrapper.getKey();
+  if (!acc.has(wrapperKey)) {
+    acc.set(wrapperKey, wrapper);
+  }
+
+  const childList = wrapper.getFirstChild();
+  if (!$isListNode(childList)) {
+    return;
+  }
+
+  for (const child of childList.getChildren()) {
+    if (!$isListItemNode(child) || !isNoteContentItem(child)) {
+      continue;
+    }
+    collectSubtree(child, acc);
+  }
+}
+
+function toTopLevelNotes(notes: ListItemNode[]): ListItemNode[] {
+  return notes.filter((candidate) =>
+    !notes.some((other) => other !== candidate && isDescendantOf(candidate, other))
+  );
+}
+
+function getNodePath(node: LexicalNode): number[] {
+  const path: number[] = [];
+  let current: LexicalNode | null = node;
+
+  while (current) {
+    const parent: LexicalNode | null = current.getParent();
+    if (!parent) {
+      break;
+    }
+    path.push(current.getIndexWithinParent());
+    current = parent;
+  }
+
+  return path.reverse();
+}
+
+function sortByDocumentOrder<T extends LexicalNode>(nodes: T[]): T[] {
+  return [...nodes].sort((a, b) => {
+    const left = getNodePath(a);
+    const right = getNodePath(b);
+    const depth = Math.max(left.length, right.length);
+
+    for (let i = 0; i < depth; i++) {
+      const l = left[i] ?? -1;
+      const r = right[i] ?? -1;
+      if (l !== r) {
+        return l - r;
+      }
+    }
+
+    return 0;
+  });
+}
+
+export function NoteSelectionPlugin() {
+  const [editor] = useLexicalComposerContext();
+
+  useEffect(() => {
+    let applying = false;
+
+    return editor.registerUpdateListener(({ editorState }) => {
+      if (applying) {
+        return;
+      }
+
+      let shouldPromote = false;
+      let targetKeys: string[] = [];
+
+      editorState.read(() => {
+        const selection = $getSelection();
+        if ($isNodeSelection(selection)) {
+          return;
+        }
+
+        if (!$isRangeSelection(selection)) {
+          return;
+        }
+
+        const contentNotes = collectContentNotesFromSelection(selection.getNodes());
+        if (contentNotes.length <= 1) {
+          return;
+        }
+
+        const topLevelNotes = sortByDocumentOrder(toTopLevelNotes(contentNotes));
+        if (topLevelNotes.length === 0) {
+          return;
+        }
+
+        const collected = new Map<string, ListItemNode>();
+        for (const note of topLevelNotes) {
+          collectSubtree(note, collected);
+        }
+
+        if (collected.size > 0) {
+          targetKeys = Array.from(collected.keys());
+          shouldPromote = true;
+        }
+      });
+
+      if (!shouldPromote) {
+        return;
+      }
+
+      applying = true;
+      try {
+        editor.update(() => {
+          const nodeSelection = $createNodeSelection();
+          for (const key of targetKeys) {
+            nodeSelection.add(key);
+          }
+          $setSelection(nodeSelection);
+        });
+      } finally {
+        applying = false;
+      }
+    });
+  }, [editor]);
+
+  return null;
+}

--- a/tests/unit/selection.spec.ts
+++ b/tests/unit/selection.spec.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+import { $getSelection, $isNodeSelection, $isRangeSelection } from 'lexical';
+import type { LexicalNode } from 'lexical';
+import { $isListItemNode } from '@lexical/list';
+import {
+  selectEntireNote,
+  selectNoteRange,
+} from '#tests';
+
+function getNodePath(node: LexicalNode): number[] {
+  const path: number[] = [];
+  let current: LexicalNode | null = node;
+
+  while (current) {
+    const parent: LexicalNode | null = current.getParent();
+    if (!parent) {
+      break;
+    }
+    path.push(current.getIndexWithinParent());
+    current = parent;
+  }
+
+  return path.reverse();
+}
+
+function sortNodesByDocumentOrder(nodes: LexicalNode[]): LexicalNode[] {
+  return [...nodes].sort((a, b) => {
+    const left = getNodePath(a);
+    const right = getNodePath(b);
+    const depth = Math.max(left.length, right.length);
+
+    for (let i = 0; i < depth; i++) {
+      const l = left[i] ?? -1;
+      const r = right[i] ?? -1;
+      if (l !== r) {
+        return l - r;
+      }
+    }
+
+    return 0;
+  });
+}
+
+function getSelectionSummary(lexical: any) {
+  return lexical.validate(() => {
+    const selection = $getSelection();
+    const summary = {
+      isRange: $isRangeSelection(selection),
+      isNode: $isNodeSelection(selection),
+      noteTexts: [] as string[],
+    };
+
+    if ($isNodeSelection(selection)) {
+      const nodes = sortNodesByDocumentOrder(selection.getNodes());
+      for (const node of nodes) {
+        if (!$isListItemNode(node)) {
+          continue;
+        }
+        const text = node
+          .getChildren()
+          .filter((child) => typeof child.getTextContent === 'function' && child.getType() !== 'list')
+          .map((child) => child.getTextContent().trim())
+          .join('')
+          .trim();
+        if (text) {
+          summary.noteTexts.push(text);
+        }
+      }
+    }
+
+    return summary;
+  });
+}
+
+describe('note selection plugin', () => {
+  it('keeps inline selections within a single note as range selections', async ({ lexical }) => {
+    lexical.load('flat');
+
+    await selectEntireNote('note1', lexical.mutate);
+
+    const summary = getSelectionSummary(lexical);
+
+    expect(summary.isRange).toBe(true);
+    expect(summary.isNode).toBe(false);
+  });
+
+  it('promotes cross-note ranges into node selections for sibling notes', async ({ lexical }) => {
+    lexical.load('flat');
+
+    await selectNoteRange('note1', 'note2', lexical.mutate);
+
+    const summary = getSelectionSummary(lexical);
+
+    expect(summary.isNode).toBe(true);
+    expect(summary.noteTexts).toEqual(['note1', 'note2']);
+  });
+
+  it('captures the entire subtree when selecting from a parent into its child', async ({ lexical }) => {
+    lexical.load('tree_complex');
+
+    await selectNoteRange('note2', 'note3', lexical.mutate);
+
+    const summary = getSelectionSummary(lexical);
+
+    expect(summary.isNode).toBe(true);
+    expect(summary.noteTexts).toEqual(['note2', 'note3']);
+  });
+
+  it('includes descendants and siblings when the selection spans them', async ({ lexical }) => {
+    lexical.load('tree_complex');
+
+    await selectNoteRange('note2', 'note5', lexical.mutate);
+
+    const summary = getSelectionSummary(lexical);
+
+    expect(summary.isNode).toBe(true);
+    expect(summary.noteTexts).toEqual(['note2', 'note3', 'note4', 'note5']);
+  });
+});


### PR DESCRIPTION
## Summary
1. Introduce a `NoteSelectionPlugin` that upgrades cross-note ranges into node selections and collects entire note subtrees so selections stay aligned with outline boundaries.
2. Wire the selection plugin into the editor and teach the indentation handler to operate on node selections as well as ranges.
3. Add unit tests that cover sibling, parent/child, and mixed-range snapping scenarios.

## Testing
1. pnpm run lint
2. pnpm run test:unit

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69120ef480088330b82fac298ddd6f4c)