### PR TITLE
Fix structural selection activation for leaf notes

### DIFF
--- a/src/editor/plugins/SelectionPlugin.tsx
+++ b/src/editor/plugins/SelectionPlugin.tsx
@@ -430,6 +430,15 @@ export function SelectionPlugin() {
           }
 
           const noopPlan = isNoopPlan(planResult);
+          if (noopPlan && planResult.plan.type === 'range') {
+            const range: StructuralSelectionRange = {
+              startKey: planResult.plan.startKey,
+              endKey: planResult.plan.endKey,
+            };
+            structuralSelectionRangeRef.current = range;
+            applyStructuralSelectionMetrics(range);
+            setStructuralSelectionActive(true);
+          }
           const applied = noopPlan || $applyProgressivePlan(planResult);
           if (!applied) {
             progressionRef.current = INITIAL_PROGRESSIVE_STATE;

--- a/tests/unit/selection.spec.ts
+++ b/tests/unit/selection.spec.ts
@@ -432,7 +432,7 @@ describe('selection plugin', () => {
     expect(snapshot.selectedNotes).toEqual(['note1', 'note2', 'note3', 'note4', 'note5', 'note6', 'note7']);
   });
 
-  it.fails('marks structural selection once Shift+Down reaches stage 2 even for leaf notes', async ({ lexical }) => {
+  it('marks structural selection once Shift+Down reaches stage 2 even for leaf notes', async ({ lexical }) => {
     lexical.load('tree_complex');
 
     const rootElement = lexical.editor.getRootElement();


### PR DESCRIPTION
## Summary
- ensure the selection plugin marks structural selection when the stage 2 plan is a no-op for leaf notes
- enable the previously failing progressive selection test for leaf notes

## Testing
- pnpm run lint
- pnpm run test:unit

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914bbfa687c8330b75895df6b68b6c2)