### PR TITLE
Fix selection fallback creation inside update scope

### DIFF
--- a/src/editor/plugins/SelectionPlugin.tsx
+++ b/src/editor/plugins/SelectionPlugin.tsx
@@ -185,30 +185,28 @@ export function SelectionPlugin() {
     };
 
     const ensureRootContentItem = (): ListItemNode | null => {
-      return editor.getEditorState().read(() => {
-        const root = $getRoot();
-        let list = root.getFirstChild();
+      const root = $getRoot();
+      let list = root.getFirstChild();
 
-        if (!$isListNode(list)) {
-          const newList = $createListNode('bullet');
-          root.append(newList);
-          list = newList;
-        }
+      if (!$isListNode(list)) {
+        const newList = $createListNode('bullet');
+        root.append(newList);
+        list = newList;
+      }
 
-        if (!$isListNode(list)) {
-          return null;
-        }
+      if (!$isListNode(list)) {
+        return null;
+      }
 
-        const first = getFirstDescendantListItem(list);
-        if (first) {
-          return getContentListItem(first);
-        }
+      const first = getFirstDescendantListItem(list);
+      if (first) {
+        return getContentListItem(first);
+      }
 
-        const listItem = $createListItemNode();
-        listItem.append($createParagraphNode());
-        list.append(listItem);
-        return listItem;
-      });
+      const listItem = $createListItemNode();
+      listItem.append($createParagraphNode());
+      list.append(listItem);
+      return listItem;
     };
 
     const unregisterRootListener = editor.registerRootListener((rootElement, previousRootElement) => {


### PR DESCRIPTION
## Summary
- create the root list item fallback within the writeable selection update instead of inside a read-only scope
- keep caret recovery from crashing when recreating an empty outline after deletions

## Testing
- pnpm run test:unit

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c4f4f374883308eb7b187429bdb8d)