### PR TITLE
Fix structural deletion fallback update context

### DIFF
--- a/src/editor/plugins/SelectionPlugin.tsx
+++ b/src/editor/plugins/SelectionPlugin.tsx
@@ -478,9 +478,8 @@ export function SelectionPlugin() {
                 targetItem = listItem;
               }
 
-              if (targetItem) {
-                caretApplied = $applyCaretEdge(targetItem.getKey(), 'start');
-              }
+              caretApplied = $applyCaretEdge(targetItem.getKey(), 'start');
+            }
           }
 
           if (!caretApplied && selection) {

--- a/src/editor/plugins/SelectionPlugin.tsx
+++ b/src/editor/plugins/SelectionPlugin.tsx
@@ -184,33 +184,6 @@ export function SelectionPlugin() {
       }
     };
 
-    const ensureRootContentItem = (): ListItemNode | null => {
-      return editor.getEditorState().read(() => {
-        const root = $getRoot();
-        let list = root.getFirstChild();
-
-        if (!$isListNode(list)) {
-          const newList = $createListNode('bullet');
-          root.append(newList);
-          list = newList;
-        }
-
-        if (!$isListNode(list)) {
-          return null;
-        }
-
-        const first = getFirstDescendantListItem(list);
-        if (first) {
-          return getContentListItem(first);
-        }
-
-        const listItem = $createListItemNode();
-        listItem.append($createParagraphNode());
-        list.append(listItem);
-        return listItem;
-      });
-    };
-
     const unregisterRootListener = editor.registerRootListener((rootElement, previousRootElement) => {
       if (previousRootElement) {
         delete previousRootElement.dataset.structuralSelection;
@@ -483,9 +456,29 @@ export function SelectionPlugin() {
           }
 
           if (!caretApplied) {
-            const fallbackItem = ensureRootContentItem();
-            if (fallbackItem) {
-              caretApplied = $applyCaretEdge(fallbackItem.getKey(), 'start');
+            const root = $getRoot();
+            let list = root.getFirstChild();
+
+            if (!$isListNode(list)) {
+              const newList = $createListNode('bullet');
+              root.append(newList);
+              list = newList;
+            }
+
+            if ($isListNode(list)) {
+              const first = getFirstDescendantListItem(list);
+              let targetItem: ListItemNode | null = null;
+
+              if (first) {
+                targetItem = getContentListItem(first);
+              } else {
+                const listItem = $createListItemNode();
+                listItem.append($createParagraphNode());
+                list.append(listItem);
+                targetItem = listItem;
+              }
+
+              caretApplied = $applyCaretEdge(targetItem.getKey(), 'start');
             }
           }
 

--- a/src/editor/plugins/SelectionPlugin.tsx
+++ b/src/editor/plugins/SelectionPlugin.tsx
@@ -478,8 +478,9 @@ export function SelectionPlugin() {
                 targetItem = listItem;
               }
 
-              caretApplied = $applyCaretEdge(targetItem.getKey(), 'start');
-            }
+              if (targetItem) {
+                caretApplied = $applyCaretEdge(targetItem.getKey(), 'start');
+              }
           }
 
           if (!caretApplied && selection) {


### PR DESCRIPTION
## Summary
- ensure the structural deletion fallback creates list content within an editor update so state is mutated in a writable scope

## Testing
- pnpm run lint
- pnpm run test:unit
- pnpm run test:unit:collab

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c57b49b8c8330a1d3d788dab55f71)