### PR TITLE
fix(build): declare correct interpreters for snapshot + dev-init — en…

### DIFF
--- a/scripts/dev-init.sh
+++ b/scripts/dev-init.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 pnpm i --frozen-lockfile
 TAG="v$(node -p "require('./node_modules/lexical/package.json').version")"
 

--- a/scripts/snapshot.ts
+++ b/scripts/snapshot.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env tsx
 import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';


### PR DESCRIPTION
…sures tsx loader runs snapshot.ts and bash executes dev-init.sh consistently