### PR TITLE
Use runtime sync helper in collaboration provider

### DIFF
--- a/lib/collaboration/runtime.ts
+++ b/lib/collaboration/runtime.ts
@@ -178,7 +178,7 @@ export function waitForSync(
     timeoutMs = 5000,
     signal,
     drainLocalChanges = true,
-  }: { timeoutMs?: number; signal?: AbortSignal; drainLocalChanges?: boolean } = {}
+  }: { timeoutMs?: number | null; signal?: AbortSignal; drainLocalChanges?: boolean } = {}
 ): Promise<void> {
   const requiresLocalClear = drainLocalChanges;
   const ready = () => provider.synced === true && (!requiresLocalClear || provider.hasLocalChanges !== true);
@@ -188,7 +188,10 @@ export function waitForSync(
   }
 
   const mergedSignal = (() => {
-    const active = [signal, AbortSignal.timeout(timeoutMs)].filter(Boolean) as AbortSignal[];
+    const active = [signal].filter(Boolean) as AbortSignal[];
+    if (timeoutMs !== null) {
+      active.push(AbortSignal.timeout(timeoutMs));
+    }
     if (active.length === 0) {
       return new AbortController().signal; // never aborted
     }


### PR DESCRIPTION
## Summary
- allow `waitForSync` to skip timeouts when requested
- delegate the collaboration provider's `awaitSynced` logic to the shared runtime helper while keeping provider state updates in sync

## Testing
- pnpm run lint
- pnpm run test:unit
- pnpm run test:unit:collab (fails to start y-sweet because the binary download requires network access)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692482d839748330924932f916bc6f6b)