### PR TITLE
Update AGENTS checks guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,8 +123,6 @@ document captures the full model.
 
 ## Checks
 
-- Guard every test command with a 60s timeout; if it times out, treat the test
-  as broken and investigate instead of extending the timeout.
 - Current timings on this machine (rounded with headroom): `pnpm run lint`
   about 5–10s, `pnpm run test:unit` about 10–20s, `pnpm run test:unit:collab`
   about 12–25s. If you ever hit the 60s guard, debug the failure (don’t extend);


### PR DESCRIPTION
## Summary
- remove the timeout guard requirement from the Checks section of AGENTS.md
- keep the remaining check timing guidance intact

## Testing
- pnpm run lint:md:file -- AGENTS.md *(fails: markdownlint-cli2 command not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69470ca17e288330acc3d1e6baa9cc47)