### PR TITLE
Remove unused contiguity helper

### DIFF
--- a/src/editor/outline/selection-utils.ts
+++ b/src/editor/outline/selection-utils.ts
@@ -3,22 +3,6 @@ import type { RangeSelection, LexicalNode } from 'lexical';
 import { reportInvariant } from '@/editor/invariant';
 import { getContentListItem, findNearestListItem } from './list-structure';
 
-// TODO: review usage; feels artificial but leave behavior unchanged for now.
-export const selectionIsContiguous = (notes: ListItemNode[], siblings: ListItemNode[]): boolean => {
-  if (notes.length === 0) return false;
-  const indexes = notes.map((note) => siblings.indexOf(note));
-  if (indexes.includes(-1)) {
-    reportInvariant({
-      message: 'Notes are not all present in sibling list for contiguity check',
-      context: { noteCount: notes.length, siblingCount: siblings.length },
-    });
-    return false;
-  }
-  const first = Math.min(...indexes);
-  const last = Math.max(...indexes);
-  return last - first + 1 === notes.length;
-};
-
 export const getSelectedNotes = (selection: RangeSelection): ListItemNode[] => {
   const ordered: ListItemNode[] = [];
   const seen = new Set<string>();


### PR DESCRIPTION
## Summary
- remove the unused contiguity helper from selection utilities

## Testing
- pnpm run lint
- pnpm run test:unit
- pnpm run test:unit:collab

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69499d3758388330992e28ad24661c4d)