### PR TITLE
Add note ID-aware list items

### DIFF
--- a/lib/editor/nodes.ts
+++ b/lib/editor/nodes.ts
@@ -1,4 +1,12 @@
 import type { InitialConfigType } from '@lexical/react/LexicalComposer';
 import { ListItemNode, ListNode } from '@lexical/list';
+import { NoteListItemNode } from '@/editor/nodes/NoteListItemNode';
 
-export const editorNodes: InitialConfigType['nodes'] = [ListNode, ListItemNode];
+export const editorNodes: InitialConfigType['nodes'] = [
+  ListNode,
+  {
+    replace: NoteListItemNode,
+    with: (node: ListItemNode) => new NoteListItemNode(node.getValue(), node.getChecked()),
+    withKlass: NoteListItemNode,
+  },
+];

--- a/src/editor/nodes/NoteListItemNode.ts
+++ b/src/editor/nodes/NoteListItemNode.ts
@@ -1,0 +1,27 @@
+import { ListItemNode } from '@lexical/list';
+import { $getState, $setState, createState, type StateConfigValue, type StateValueOrUpdater } from 'lexical';
+
+export const noteIdState = createState('noteId', {
+  parse: (value) => (typeof value === 'string' ? value : undefined),
+});
+
+export class NoteListItemNode extends ListItemNode {
+  override $config() {
+    const baseConfig = super.$config();
+    const stateConfigs = [...(baseConfig.stateConfigs ?? []), { flat: true, stateConfig: noteIdState }];
+
+    return {
+      ...baseConfig,
+      stateConfigs,
+    };
+  }
+
+  getNoteId(): StateConfigValue<typeof noteIdState> {
+    return $getState(this, noteIdState);
+  }
+
+  setNoteId(valueOrUpdater: StateValueOrUpdater<typeof noteIdState>): this {
+    $setState(this, noteIdState, valueOrUpdater);
+    return this;
+  }
+}

--- a/tests/fixtures/empty-labels.json
+++ b/tests/fixtures/empty-labels.json
@@ -7,6 +7,7 @@
         "children": [
           {
             "type": "listitem",
+            "noteId": "alpha",
             "value": 1,
             "children": [
               {
@@ -17,6 +18,7 @@
           },
           {
             "type": "listitem",
+            "noteId": "whitespace",
             "value": 2,
             "children": [
               {
@@ -27,6 +29,7 @@
           },
           {
             "type": "listitem",
+            "noteId": "beta",
             "value": 3,
             "children": [
               {
@@ -37,11 +40,13 @@
           },
           {
             "type": "listitem",
+            "noteId": "empty",
             "value": 4,
             "children": []
           },
           {
             "type": "listitem",
+            "noteId": "parent-empty-list",
             "value": 5,
             "children": [
               {
@@ -50,12 +55,14 @@
                   {
                     "indent": 1,
                     "type": "listitem",
+                    "noteId": "nested-empty",
                     "value": 1,
                     "children": []
                   },
                   {
                     "indent": 1,
                     "type": "listitem",
+                    "noteId": "child-of-empty",
                     "value": 2,
                     "children": [
                       {

--- a/tests/unit/selection.spec.ts
+++ b/tests/unit/selection.spec.ts
@@ -5,6 +5,7 @@ import {
   collectSelectedListItems,
   getListItemLabel,
   placeCaretAtNote,
+  placeCaretAtNoteId,
   pressKey,
   readOutline,
   typeText,
@@ -1143,7 +1144,7 @@ describe('selection plugin', () => {
   it('skips the inline stage for whitespace-only notes on Cmd/Ctrl+A', async ({ remdo }) => {
     await remdo.load('empty-labels');
 
-    await placeCaretAtNote(remdo, ' ');
+    await placeCaretAtNoteId(remdo, 'whitespace');
     await pressKey(remdo, { key: 'a', ctrlOrMeta: true });
 
     expect(remdo).toMatchSelection({ state: 'structural', notes: [' '] });


### PR DESCRIPTION
## Summary
- add a NoteListItemNode with noteId state support and register it as the listitem replacement
- update fixtures and helpers to work with noteId-based lookup for list items
- switch a selection test to the new noteId helper for readability

## Testing
- pnpm run test:unit tests/unit/selection.spec.ts -t "skips the inline stage for whitespace-only notes on Cmd/Ctrl+A"


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b13524bec83308eaa1bba7d3cca17)