### PR TITLE
fix(prod-docker): validate APP_PUBLIC_URL derived port — move unsafe-…

### DIFF
--- a/src/client/editor/plugins/PendingDocumentImportPlugin.tsx
+++ b/src/client/editor/plugins/PendingDocumentImportPlugin.tsx
@@ -26,7 +26,7 @@ function waitForEditorUpdate(editor: ReturnType<typeof useLexicalComposerContext
 
 export function PendingDocumentImportPlugin({ onError }: PendingDocumentImportPluginProps): null {
   const [editor] = useLexicalComposerContext();
-  const { awaitSynced, docId, hydrated } = useCollaborationStatus();
+  const { docId, hydrated, session } = useCollaborationStatus();
 
   useEffect(() => {
     if (!hydrated) {
@@ -60,7 +60,7 @@ export function PendingDocumentImportPlugin({ onError }: PendingDocumentImportPl
         }, { tag: NOTE_ID_NORMALIZE_TAG });
         await normalizeUpdate;
 
-        await awaitSynced();
+        await session.awaitSynced();
       } catch (error) {
         if (!lifecycle.cancelled) {
           onError(error instanceof Error ? error : new Error('Failed to upload document.'));
@@ -71,7 +71,7 @@ export function PendingDocumentImportPlugin({ onError }: PendingDocumentImportPl
     return () => {
       lifecycle.cancelled = true;
     };
-  }, [awaitSynced, docId, editor, hydrated, onError]);
+  }, [docId, editor, hydrated, onError, session]);
 
   return null;
 }

--- a/tests/e2e/editor/document-switcher.spec.ts
+++ b/tests/e2e/editor/document-switcher.spec.ts
@@ -83,6 +83,9 @@ test.describe('Document switcher', () => {
     });
 
     await expect(page).toHaveURL(createEditorDocumentPath(createdDocId));
+    await editorLocator(page).locator('.editor-input').first().waitFor();
+    await ensureReady(page);
+    await waitForSynced(page);
     await expect(editorLocator(page).locator('li.list-item', { hasText: 'note7' }).first()).toBeVisible();
 
     await page.getByRole('button', { name: 'Choose document' }).click();

--- a/tests/unit/prod-docker-launcher.spec.ts
+++ b/tests/unit/prod-docker-launcher.spec.ts
@@ -1,0 +1,164 @@
+/* eslint-disable node/no-process-env */
+import { spawnSync } from 'node:child_process';
+import type { SpawnSyncReturns } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+function writeFakeDocker(binDir: string): void {
+  const dockerPath = path.join(binDir, 'docker');
+  fs.writeFileSync(dockerPath, `#!/usr/bin/env sh
+set -eu
+printf '%s\\n' "$*" >> "\${REMDO_FAKE_DOCKER_LOG:?}"
+case "$1" in
+  build)
+    exit 0
+    ;;
+  info)
+    printf '%s\\n' '["name=rootless"]'
+    exit 0
+    ;;
+  run)
+    exit 0
+    ;;
+  *)
+    echo "unexpected docker command: $1" >&2
+    exit 1
+    ;;
+esac
+`);
+  fs.chmodSync(dockerPath, 0o755);
+}
+
+interface LauncherRun {
+  result: SpawnSyncReturns<string>;
+  dockerCalls: string;
+}
+
+describe('prod Docker launcher', () => {
+  let tempDirs: string[] = [];
+
+  beforeEach(() => {
+    tempDirs = [];
+  });
+
+  afterEach(() => {
+    for (const tempDir of tempDirs) {
+      fs.rmSync(tempDir, { force: true, recursive: true });
+    }
+  });
+
+  function runLauncher(overrides: Record<string, string>): LauncherRun {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'remdo-prod-docker-launcher-'));
+    tempDirs.push(tempDir);
+    const binDir = path.join(tempDir, 'bin');
+    const dataDir = path.join(tempDir, 'data');
+    const dockerLog = path.join(tempDir, 'docker.log');
+    fs.mkdirSync(binDir);
+    writeFakeDocker(binDir);
+
+    const result = spawnSync('./tools/prod/docker.sh', {
+      cwd: process.cwd(),
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        ADMIN_SECRET: 'production-admin-secret-0123456789',
+        AUTH_SECRET: 'production-auth-secret-0123456789',
+        DATA_DIR: dataDir,
+        HOSTNAME: 'remdo-test',
+        PATH: `${binDir}:${process.env.PATH}`,
+        REMDO_FAKE_DOCKER_LOG: dockerLog,
+        YSWEET_AUTH_KEY: 'production-ysweet-auth-key',
+        YSWEET_SERVER_TOKEN: 'production-ysweet-server-token',
+        // Neutralize every port-related input so the run is hermetic against
+        // the developer's shell and the repo .env (empty string counts as set).
+        APP_PUBLIC_URL: '',
+        AUTH_URL: '',
+        PORT: '',
+        PORT_BASE: '',
+        RUN_MODE_PORT_SHIFT: '',
+        ...overrides,
+      },
+    });
+
+    const dockerCalls = result.status === 0 ? fs.readFileSync(dockerLog, 'utf8') : '';
+    return { result, dockerCalls };
+  }
+
+  it('launches when only a Caddy-internal derived port lands on a Chromium-blocked port', () => {
+    // The launcher's +40 shift derives PREVIEW_PORT=4045 (PORT_BASE 4000), which
+    // is on Chromium's blocked-port list. Inside the prod container every derived
+    // service is reached through Caddy, so only the public PORT (8080) is
+    // browser-facing; a blocked derived port must not abort the prod launch.
+    const { result, dockerCalls } = runLauncher({
+      PORT_BASE: '4000',
+      APP_PUBLIC_URL: 'https://remdo-test:8080',
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).not.toContain('blocked by Chromium');
+    expect(result.stdout).toContain('Docker target: https://remdo-test:8080');
+
+    expect(dockerCalls).toContain('build ');
+    expect(dockerCalls).toContain('info --format {{json .SecurityOptions}}');
+    expect(dockerCalls).toContain('run ');
+    expect(dockerCalls).toContain('-e PORT_BASE=4000');
+    expect(dockerCalls).toContain('-e PORT=8080');
+    expect(dockerCalls).toContain('-p 8080:8080');
+  });
+
+  it('aborts when the browser-facing PORT is a Chromium-blocked port', () => {
+    // 6666 is on Chromium's blocked list; serving the public site there would
+    // give real users ERR_UNSAFE_PORT, so the launcher must refuse to start.
+    const { result } = runLauncher({
+      PORT_BASE: '4000',
+      APP_PUBLIC_URL: 'https://remdo-test:6666',
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('Port 6666 is blocked by Chromium');
+  });
+
+  it('derives the public port and target from APP_PUBLIC_URL', () => {
+    const { result, dockerCalls } = runLauncher({
+      PORT_BASE: '4000',
+      APP_PUBLIC_URL: 'https://remdo-test.example:443',
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Docker target: https://remdo-test.example:443');
+    expect(dockerCalls).toContain('-e PORT=443');
+    expect(dockerCalls).toContain('-p 443:443');
+  });
+
+  it('validates the APP_PUBLIC_URL port instead of a provisional shifted PORT', () => {
+    // PORT_BASE 4005 would derive provisional PORT=4045 with the prod +40 shift,
+    // but explicit APP_PUBLIC_URL owns the browser-facing port.
+    const { result, dockerCalls } = runLauncher({
+      PORT_BASE: '4005',
+      APP_PUBLIC_URL: 'https://remdo-test:8080',
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).not.toContain('Port 4045 is blocked by Chromium');
+    expect(result.stdout).toContain('Docker target: https://remdo-test:8080');
+    expect(dockerCalls).toContain('-e PORT_BASE=4005');
+    expect(dockerCalls).toContain('-e PORT=8080');
+    expect(dockerCalls).toContain('-p 8080:8080');
+  });
+
+  it('preserves an APP_PUBLIC_URL port that matches PORT_BASE', () => {
+    const { result, dockerCalls } = runLauncher({
+      PORT_BASE: '4000',
+      APP_PUBLIC_URL: 'https://remdo-test:4000',
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Docker target: https://remdo-test:4000');
+    expect(dockerCalls).toContain('-e PORT_BASE=4000');
+    expect(dockerCalls).toContain('-e PORT=4000');
+    expect(dockerCalls).toContain('-p 4000:4000');
+  });
+});

--- a/tools/env.defaults.sh
+++ b/tools/env.defaults.sh
@@ -10,7 +10,9 @@
 requested_run_mode_port_shift="${RUN_MODE_PORT_SHIFT}"
 unshifted_port_base="${PORT_BASE}"
 run_mode_port_base=$((PORT_BASE + requested_run_mode_port_shift))
-if [ "${requested_run_mode_port_shift}" != "0" ] && [ "${PORT:-}" = "${unshifted_port_base}" ]; then
+if [ "${requested_run_mode_port_shift}" != "0" ] \
+  && [ "${REMDO_PRESERVE_PORT:-false}" != "true" ] \
+  && [ "${PORT:-}" = "${unshifted_port_base}" ]; then
   unset PORT
 fi
 RUN_MODE_PORT_SHIFT=0
@@ -64,30 +66,46 @@ case "${NODE_ENV}" in
     ;;
 esac
 
-# Chromium blocks these ports; fail fast if base or derived ports land on one.
-restricted_ports="0 1 7 9 11 13 15 17 19 20 21 22 23 25 37 42 43 53 69 77 79 87 95 \
+# Chromium refuses to connect to these ports (ERR_UNSAFE_PORT). Exposed as a
+# function so callers that resolve the public port later (e.g. the prod launcher
+# deriving PORT from APP_PUBLIC_URL) can re-validate it.
+# Variables are _rbsp_-prefixed because POSIX sh has no `local`; this avoids
+# leaking them into the global scope of every script that sources this file.
+remdo_assert_browser_safe_port() {
+  _rbsp_port="$1"
+  _rbsp_restricted_ports="0 1 7 9 11 13 15 17 19 20 21 22 23 25 37 42 43 53 69 77 79 87 95 \
 101 102 103 104 109 110 111 113 115 117 119 123 135 137 139 143 161 179 389 427 \
 465 512 513 514 515 526 530 531 532 540 548 554 556 563 587 601 636 989 990 993 \
 995 1719 1720 1723 2049 3659 4045 5060 5061 6000 6566 6665 6666 6667 6668 6669 \
 6697 10080"
-
-for derived_port in \
-  "${PORT}" \
-  "${HMR_PORT}" \
-  "${VITEST_PORT}" \
-  "${VITEST_PREVIEW_PORT}" \
-  "${COLLAB_SERVER_PORT}" \
-  "${PREVIEW_PORT}" \
-  "${PLAYWRIGHT_UI_PORT}" \
-  "${API_SERVER_PORT}"
-do
-  for restricted_port in ${restricted_ports}; do
-    if [ "${derived_port}" = "${restricted_port}" ]; then
-      echo "Port ${derived_port} is blocked by Chromium. Pick a different PORT_BASE." >&2
+  for _rbsp_restricted_port in ${_rbsp_restricted_ports}; do
+    if [ "${_rbsp_port}" = "${_rbsp_restricted_port}" ]; then
+      echo "Port ${_rbsp_port} is blocked by Chromium (ERR_UNSAFE_PORT). Pick a different PORT or PORT_BASE." >&2
       exit 1
     fi
   done
-done
+}
+
+# The public PORT is browser-facing in every mode, so always validate it.
+remdo_assert_browser_safe_port "${PORT}"
+
+# In dev/test there is no Caddy in front: the browser connects directly to the
+# Vite/HMR/preview/Playwright servers and (for collaboration) to the collab and
+# API servers, so each derived port must be browser-safe too. The prod container
+# routes everything through Caddy, so only PORT above is browser-facing there.
+if [ "${NODE_ENV}" != "production" ]; then
+  for derived_port in \
+    "${HMR_PORT}" \
+    "${VITEST_PORT}" \
+    "${VITEST_PREVIEW_PORT}" \
+    "${COLLAB_SERVER_PORT}" \
+    "${PREVIEW_PORT}" \
+    "${PLAYWRIGHT_UI_PORT}" \
+    "${API_SERVER_PORT}"
+  do
+    remdo_assert_browser_safe_port "${derived_port}"
+  done
+fi
 
 export NODE_ENV HOST PORT_BASE RUN_MODE_PORT_SHIFT PORT DATA_DIR COLLAB_ENABLED DEV_DOCUMENT_ID CI VITEST_PREVIEW TMPDIR
 export HMR_PORT VITEST_PORT VITEST_PREVIEW_PORT COLLAB_SERVER_PORT API_SERVER_PORT YSWEET_CONNECTION_STRING

--- a/tools/prod/docker.sh
+++ b/tools/prod/docker.sh
@@ -9,21 +9,29 @@ IMAGE_NAME="${IMAGE_NAME:-remdo}"
 remdo_load_dotenv "${ROOT_DIR}"
 NODE_ENV=production
 export NODE_ENV
+
+if [[ -n "${APP_PUBLIC_URL:-}" ]]; then
+  if ! PORT="$(node -e '
+    const url = new URL(process.argv[1]);
+    const port = url.port || (url.protocol === "https:" ? "443" : url.protocol === "http:" ? "80" : "");
+    if (!port) process.exit(1);
+    console.log(port);
+  ' "${APP_PUBLIC_URL}")"; then
+    echo "APP_PUBLIC_URL must be an absolute http(s) URL." >&2
+    exit 1
+  fi
+  # shellcheck disable=SC2034 # consumed by the sourced tools/env.defaults.sh.
+  REMDO_PRESERVE_PORT=true
+  export PORT
+fi
+
 : "${RUN_MODE_PORT_SHIFT:=40}"
 remdo_load_env_defaults "${ROOT_DIR}"
 if [[ -z "${APP_PUBLIC_URL:-}" ]]; then
   remdo_configure_docker_runtime
 fi
-if ! PORT="$(node -e '
-  const url = new URL(process.argv[1]);
-  const port = url.port || (url.protocol === "https:" ? "443" : url.protocol === "http:" ? "80" : "");
-  if (!port) process.exit(1);
-  console.log(port);
-' "${APP_PUBLIC_URL}")"; then
-  echo "APP_PUBLIC_URL must be an absolute http(s) URL." >&2
-  exit 1
-fi
-export PORT
+# PORT is already validated by remdo_load_env_defaults above; remdo_configure_docker_runtime
+# only derives APP_PUBLIC_URL from it and never changes it.
 
 : "${AUTH_SECRET:?Set AUTH_SECRET in .env}"
 : "${ADMIN_SECRET:?Set ADMIN_SECRET in .env}"


### PR DESCRIPTION
…port checks to browser-facing PORT and add prod launcher coverage for blocked/public port validation