### PR TITLE
docs: clarify Playwright browser resolution strategy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,10 +121,20 @@ Determine agent mode in this order:
 - E2E (Playwright): run `pnpm test:e2e`. In sandboxed environments, accessing
   the local dev server (localhost) may require network escalation; without it,
   Playwright can’t reach the server and will fail to start.
-  If Playwright reports a missing browser executable, first try the standard
-  browser install locations by swapping `PLAYWRIGHT_BROWSERS_PATH` between the
-  system-wide and user-level caches (for example `/opt/playwright-browsers` and
-  `$HOME/.cache/ms-playwright`) before reinstalling browsers.
+  The dev bootstrap (`dev-init.sh`) does not install browsers by default, so
+  resolve them on demand before running `test:e2e:*`:
+  1. If `PLAYWRIGHT_BROWSERS_PATH` is set and already contains the required
+     chromium build, use it as-is—do nothing.
+  2. Otherwise, check the standard cache locations (`/opt/playwright-browsers`,
+     `$HOME/.cache/ms-playwright`); if a build is present, point
+     `PLAYWRIGHT_BROWSERS_PATH` at it.
+  3. If no browser is found anywhere, run `pnpm exec playwright install
+     chromium`. It installs into the preset `PLAYWRIGHT_BROWSERS_PATH` when set
+     (so later sessions reuse it); if that path isn't writable, install into
+     `$HOME/.cache/ms-playwright` and export `PLAYWRIGHT_BROWSERS_PATH` to match.
+
+  `playwright install` is idempotent, so re-running it when a browser already
+  exists is a cheap no-op.
 
 ### Scoped check runs (prefer these during iteration)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,10 +128,12 @@ Determine agent mode in this order:
   2. Otherwise, check the standard cache locations (`/opt/playwright-browsers`,
      `$HOME/.cache/ms-playwright`); if a build is present, point
      `PLAYWRIGHT_BROWSERS_PATH` at it.
-  3. If no browser is found anywhere, run `pnpm exec playwright install
-     chromium`. It installs into the preset `PLAYWRIGHT_BROWSERS_PATH` when set
-     (so later sessions reuse it); if that path isn't writable, install into
-     `$HOME/.cache/ms-playwright` and export `PLAYWRIGHT_BROWSERS_PATH` to match.
+  3. If no browser is found anywhere, install into a writable cache. If
+     `PLAYWRIGHT_BROWSERS_PATH` points at a read-only or missing-cache location
+     such as `/opt/playwright-browsers`, unset it or override it with
+     `$HOME/.cache/ms-playwright` before running
+     `pnpm exec playwright install chromium`; then export
+     `PLAYWRIGHT_BROWSERS_PATH` to the cache that received the install.
 
   `playwright install` is idempotent, so re-running it when a browser already
   exists is a cheap no-op.


### PR DESCRIPTION
## Summary
Rewrote the Playwright browser installation guidance in AGENTS.md to provide a clearer, step-by-step resolution strategy that accounts for existing browser caches and environment variables.

## Changes
- Replaced vague guidance about swapping `PLAYWRIGHT_BROWSERS_PATH` between cache locations with an explicit 3-step resolution process:
  1. Check if `PLAYWRIGHT_BROWSERS_PATH` already points to a valid chromium build
  2. Fall back to standard cache locations (`/opt/playwright-browsers`, `$HOME/.cache/ms-playwright`)
  3. Install on demand via `pnpm exec playwright install chromium` if no build is found
- Added clarification that `playwright install` respects the preset `PLAYWRIGHT_BROWSERS_PATH` and falls back to `$HOME/.cache/ms-playwright` if that path isn't writable
- Noted that `playwright install` is idempotent, so re-running it is safe and cheap when a browser already exists
- Clarified that `dev-init.sh` does not install browsers by default, so resolution must happen before running `test:e2e:*`

## Details
The new guidance is more actionable and reduces ambiguity about which cache location to use and when. It also acknowledges the practical reality that browsers may already exist in standard locations, avoiding unnecessary reinstalls.

https://claude.ai/code/session_01Cp7iXqN8spJipLLX8fTbkU