### PR TITLE
Fix localhost subdomain resolution in Playwright e2e tests

### DIFF
--- a/tools/docker-test.sh
+++ b/tools/docker-test.sh
@@ -121,11 +121,15 @@ fi
 echo "Ensuring Playwright Chromium is installed (${PLAYWRIGHT_BROWSERS_DIR})..."
 PLAYWRIGHT_BROWSERS_PATH="${PLAYWRIGHT_BROWSERS_DIR}" pnpm exec playwright install chromium
 
+# Playwright resolves `page.request` hosts via the host OS, not Chromium, so the
+# *.localhost app host must map to loopback. Patch it in-process for this run
+# (and inherited worker/webServer processes) instead of touching /etc/hosts.
 PLAYWRIGHT_ENV=(
   PLAYWRIGHT_BROWSERS_PATH="${PLAYWRIGHT_BROWSERS_DIR}"
   APP_PUBLIC_URL="${APP_PUBLIC_URL}"
   ADMIN_SECRET="${DOCKER_TEST_ADMIN_SECRET}"
   YSWEET_SERVER_TOKEN="${DOCKER_TEST_YSWEET_SERVER_TOKEN}"
+  NODE_OPTIONS="${NODE_OPTIONS:+${NODE_OPTIONS} }--require ${ROOT_DIR}/tools/e2e/localhost-dns.cjs"
 )
 
 if ! env "${PLAYWRIGHT_ENV[@]}" \

--- a/tools/e2e/localhost-dns.cjs
+++ b/tools/e2e/localhost-dns.cjs
@@ -1,0 +1,38 @@
+// Resolve *.localhost subdomains (e.g. remdo.localhost) to loopback for this
+// process only. Playwright's request context resolves hosts via the host OS
+// rather than Chromium, so `page.request` to a *.localhost app host fails on
+// systems without nss-myhostname / systemd-resolved. RFC 6761 reserves
+// `localhost` and its subdomains for loopback, so this never affects real
+// names. Loaded via NODE_OPTIONS=--require; nothing is written to disk and the
+// override disappears when the process exits.
+const dns = require('node:dns');
+const process = require('node:process');
+
+const LOOPBACK = '127.0.0.1';
+const LOCALHOST_SUBDOMAIN = /\.localhost$/i;
+const isLocalhostSubdomain = host => typeof host === 'string' && LOCALHOST_SUBDOMAIN.test(host);
+
+const realLookup = dns.lookup;
+dns.lookup = function lookup(hostname, options, callback) {
+  if (!isLocalhostSubdomain(hostname)) {
+    return realLookup.call(this, hostname, options, callback);
+  }
+  const cb = typeof options === 'function' ? options : callback;
+  const wantsAll = typeof options === 'object' && options !== null && options.all === true;
+  process.nextTick(() => {
+    if (wantsAll) {
+      cb(null, [{ address: LOOPBACK, family: 4 }]);
+    } else {
+      cb(null, LOOPBACK, 4);
+    }
+  });
+};
+
+const realLookupPromise = dns.promises.lookup;
+dns.promises.lookup = function lookup(hostname, options) {
+  if (!isLocalhostSubdomain(hostname)) {
+    return realLookupPromise.call(this, hostname, options);
+  }
+  const wantsAll = typeof options === 'object' && options !== null && options.all === true;
+  return Promise.resolve(wantsAll ? [{ address: LOOPBACK, family: 4 }] : { address: LOOPBACK, family: 4 });
+};


### PR DESCRIPTION
## Summary
Adds DNS resolution patching for `*.localhost` subdomains in e2e tests to ensure Playwright's `page.request` can reach locally-hosted apps. This resolves test failures on systems without `nss-myhostname` or `systemd-resolved`.

## Changes
- **New file: `tools/e2e/localhost-dns.cjs`** — In-process DNS resolver that intercepts `dns.lookup()` calls and maps `*.localhost` subdomains to `127.0.0.1`. Patches both callback and promise-based APIs. Loaded via `NODE_OPTIONS=--require` to affect the test process and inherited worker/webServer subprocesses without modifying system files.

- **Modified: `tools/docker-test.sh`** — Adds `NODE_OPTIONS` environment variable to the Playwright test invocation, loading the localhost DNS resolver. Includes explanatory comments about why this is needed (Playwright resolves hosts via the OS, not Chromium).

## Implementation Details
- Uses RFC 6761 reserved `localhost` domain to safely intercept only test subdomains; never affects real hostnames
- Handles both `dns.lookup(hostname, callback)` and `dns.lookup(hostname, options, callback)` signatures
- Supports the `all` option to return either a single address or an array of addresses
- Resolver is ephemeral — only active during the test process, no persistent system changes

https://claude.ai/code/session_01UGq8DY2jtPxn4ZeUFVBhMQ