### PR TITLE
fix(docker): default HOST to IPv4 loopback in container entrypoint — …

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -14,6 +14,14 @@ export REMDO_ROOT
 : "${XDG_CONFIG_HOME:=${DATA_DIR%/}/.config}"
 export XDG_DATA_HOME XDG_CONFIG_HOME
 
+# Bind loopback services on IPv4. Caddy proxies to 127.0.0.1 upstreams, but
+# `localhost` (the env.defaults.sh default) can resolve to ::1 first, so the API
+# server would listen IPv6-only and Caddy's IPv4 dial gets connection-refused.
+# Pin HOST to the IPv4 loopback the Caddyfile uses. Override-able for callers
+# (e.g. the docker E2E) that set it explicitly.
+: "${HOST:=127.0.0.1}"
+export HOST
+
 remdo_configure_caddy_env
 
 # Bootstrap secrets (production only). Resolves AUTH_SECRET and the Y-Sweet

--- a/docs/config.md
+++ b/docs/config.md
@@ -27,7 +27,7 @@ variables — is derived or bootstrapped, never set in the normal path.
 | `DATA_DIR`        | optional   | optional           | Persistence root for data and bootstrapped secrets; prod should point it at a persistent mount. |
 | `PORT_BASE`       | optional   | —                  | Dev port base; `PORT` and all secondary ports derive from it. |
 | `PORT`            | derived    | optional           | Listen/bind port only; the one prod knob, defaults to `8080`. |
-| `HOST`            | optional   | fixed in-container | Bind host.                                                    |
+| `HOST`            | optional   | fixed in-container | Bind host. The container entrypoint pins it to `127.0.0.1` so the API listens on the IPv4 loopback Caddy proxies to (`localhost` can resolve to `::1`, leaving the API IPv6-only and unreachable). |
 | `APP_PUBLIC_URL`  | —          | required           | Canonical public origin (see below).                          |
 | `ADMIN_SECRET`    | optional   | required           | Operator secret for admin provisioning.                       |
 | `ALLOW_SIGNUP`    | optional   | optional           | Signup policy. Defaults true outside production, false in it. |

--- a/tests/unit/docker-entrypoint-env.spec.ts
+++ b/tests/unit/docker-entrypoint-env.spec.ts
@@ -85,6 +85,41 @@ describe('docker entrypoint Caddy environment', () => {
   });
 });
 
+describe('docker entrypoint HOST default', () => {
+  // The entrypoint pins HOST to the IPv4 loopback so the API server does not
+  // bind IPv6-only (`localhost` can resolve to ::1), which would leave Caddy's
+  // 127.0.0.1 upstreams unreachable. Extract the defaulting line from the real
+  // entrypoint so the test tracks the source rather than a hard-coded copy.
+  function resolveHost(overrides: NodeJS.ProcessEnv): string {
+    const output = execFileSync(
+      'sh',
+      [
+        '-c',
+        [
+          String.raw`eval "$(grep -E '^: "\$\{HOST:=' docker/entrypoint.sh)"`,
+          'printf "%s" "$HOST"',
+        ].join('; '),
+      ],
+      {
+        env: {
+          PATH: process.env.PATH,
+          ...overrides,
+        },
+        encoding: 'utf8',
+      }
+    );
+    return output;
+  }
+
+  it('defaults HOST to the IPv4 loopback', () => {
+    expect(resolveHost({})).toBe('127.0.0.1');
+  });
+
+  it('honors an explicit HOST override', () => {
+    expect(resolveHost({ HOST: '0.0.0.0' })).toBe('0.0.0.0');
+  });
+});
+
 describe('docker entrypoint API secret validation', () => {
   it('requires AUTH_SECRET', () => {
     const result = runEntryPointEnv('remdo_require_api_secrets', {


### PR DESCRIPTION
…prevent Caddy targeting unreachable IPv6 localhost by pinning HOST default and documenting behavior with unit coverage