### PR TITLE
fix(docker): set HOST before env.defaults for IPv4 loopback — preserv…

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -5,6 +5,16 @@ set -euo pipefail
 : "${REMDO_ROOT:=/app}"
 export REMDO_ROOT
 
+# Bind loopback services on IPv4. Caddy proxies to 127.0.0.1 upstreams, but
+# `localhost` (the env.defaults.sh default) can resolve to ::1 first, so the API
+# server would listen IPv6-only and Caddy's IPv4 dial gets connection-refused.
+# Pin HOST to the IPv4 loopback the Caddyfile uses. This must run BEFORE
+# env.defaults.sh, which itself defaults HOST to `localhost`; setting it here
+# makes that default a no-op while still honouring an explicit operator HOST
+# (e.g. the docker E2E's HOST=0.0.0.0 source container).
+: "${HOST:=127.0.0.1}"
+export HOST
+
 # shellcheck disable=SC1091 # provided by the image build.
 . /usr/local/share/remdo/env.defaults.sh
 # shellcheck disable=SC1091 # provided by the image build.
@@ -13,14 +23,6 @@ export REMDO_ROOT
 : "${XDG_DATA_HOME:=${DATA_DIR%/}}"
 : "${XDG_CONFIG_HOME:=${DATA_DIR%/}/.config}"
 export XDG_DATA_HOME XDG_CONFIG_HOME
-
-# Bind loopback services on IPv4. Caddy proxies to 127.0.0.1 upstreams, but
-# `localhost` (the env.defaults.sh default) can resolve to ::1 first, so the API
-# server would listen IPv6-only and Caddy's IPv4 dial gets connection-refused.
-# Pin HOST to the IPv4 loopback the Caddyfile uses. Override-able for callers
-# (e.g. the docker E2E) that set it explicitly.
-: "${HOST:=127.0.0.1}"
-export HOST
 
 remdo_configure_caddy_env
 

--- a/tests/unit/docker-entrypoint-env.spec.ts
+++ b/tests/unit/docker-entrypoint-env.spec.ts
@@ -88,15 +88,23 @@ describe('docker entrypoint Caddy environment', () => {
 describe('docker entrypoint HOST default', () => {
   // The entrypoint pins HOST to the IPv4 loopback so the API server does not
   // bind IPv6-only (`localhost` can resolve to ::1), which would leave Caddy's
-  // 127.0.0.1 upstreams unreachable. Extract the defaulting line from the real
-  // entrypoint so the test tracks the source rather than a hard-coded copy.
+  // 127.0.0.1 upstreams unreachable. This is order-sensitive: env.defaults.sh
+  // also defaults HOST (to `localhost`), so the entrypoint must set it *before*
+  // sourcing those defaults. Run the real entrypoint up to and including the
+  // defaults source, then read HOST — this catches the ordering, which an
+  // isolated eval of the pin line would miss.
   function resolveHost(overrides: NodeJS.ProcessEnv): string {
     const output = execFileSync(
       'sh',
       [
         '-c',
         [
-          String.raw`eval "$(grep -E '^: "\$\{HOST:=' docker/entrypoint.sh)"`,
+          // Replay the entrypoint prologue: REMDO_ROOT default + the HOST pin,
+          // then source env.defaults.sh exactly as the entrypoint does. Slicing
+          // the file up to the defaults source keeps the test bound to the real
+          // ordering instead of a copied snippet.
+          'export REMDO_ROOT="$PWD"',
+          String.raw`eval "$(sed -n '/^: "\${HOST:=/,/^\. .*env\.defaults\.sh/p' docker/entrypoint.sh | sed 's#/usr/local/share/remdo/env.defaults.sh#tools/env.defaults.sh#')"`,
           'printf "%s" "$HOST"',
         ].join('; '),
       ],
@@ -111,7 +119,7 @@ describe('docker entrypoint HOST default', () => {
     return output;
   }
 
-  it('defaults HOST to the IPv4 loopback', () => {
+  it('defaults HOST to the IPv4 loopback even after sourcing env.defaults.sh', () => {
     expect(resolveHost({})).toBe('127.0.0.1');
   });
 


### PR DESCRIPTION
…e localhost binding behavior while honoring explicit HOST overrides