### PR TITLE
docs(skills): split refine into range and working-tree flow — clarify…

### DIFF
--- a/.claude/skills/remdo-feature-flow/SKILL.md
+++ b/.claude/skills/remdo-feature-flow/SKILL.md
@@ -72,13 +72,15 @@ memory-carried.
 
 ## Phase 3 — Spec approval (the one user gate)
 
-**Precondition — only this flow's own changes in the tree.** Before doing
-anything else in this phase, the working tree must hold **only this flow's own
-spec edits**. If it had pre-existing unrelated edits when the run started,
-**stop**: the working-tree refine pass below would sweep them in, and committing
-or branching could too. The user commits or sets them aside first (never do it
-for them — see AGENTS.md). This guarantee is what lets the refine step and branch
-creation below operate on the spec alone.
+**Precondition — no unrelated changes in the tree.** The check is on what the run
+did **not** produce: when the run started, were there pre-existing tracked edits
+unrelated to this flow? If so, **stop** before the refine pass and branch
+creation below — the working-tree refine would sweep them in, and committing or
+branching could too. The user commits or sets them aside first (never do it for
+them — see AGENTS.md). Everything this flow itself produced is fine and expected
+— the spec docs written below, and any flow-owned `docs/todo.md` notes from
+Phase 2 — so a normal clean-start run (where the only changes are this flow's)
+passes this gate; it is not a requirement that "only spec edits" exist.
 
 **The spec is the versioned-doc changes themselves**, written so the docs read as
 if everything already works as described (per the `docs/` invariant: stable docs
@@ -102,8 +104,8 @@ first draft. This gates only the final handoff: dialog (Phase 2) stays fast and
 unrefined, and the pass runs once here at the gate, not per turn. It is
 working-tree scope because no branch exists yet (created on approval below); it
 commits nothing, and a later rejection still reverts the edits cleanly. The
-precondition above guarantees the tree holds only this spec, so the pass sees
-nothing unrelated.
+precondition above guarantees the tree holds only this flow's own changes, so the
+pass sees nothing unrelated.
 
 The user reviews the **`docs/` changes** (the chat message is a thin pointer:
 which docs changed, plus a ~5-bullet approach summary — not the design pasted

--- a/.claude/skills/remdo-feature-flow/SKILL.md
+++ b/.claude/skills/remdo-feature-flow/SKILL.md
@@ -72,6 +72,14 @@ memory-carried.
 
 ## Phase 3 — Spec approval (the one user gate)
 
+**Precondition — only this flow's own changes in the tree.** Before doing
+anything else in this phase, the working tree must hold **only this flow's own
+spec edits**. If it had pre-existing unrelated edits when the run started,
+**stop**: the working-tree refine pass below would sweep them in, and committing
+or branching could too. The user commits or sets them aside first (never do it
+for them — see AGENTS.md). This guarantee is what lets the refine step and branch
+creation below operate on the spec alone.
+
 **The spec is the versioned-doc changes themselves**, written so the docs read as
 if everything already works as described (per the `docs/` invariant: stable docs
 describe *target* behavior). Edit the relevant docs under `docs/` — or add new
@@ -87,6 +95,16 @@ doc edits.
 `.agent/specs/...` is **not** a review surface — it is your own scratch/cache for
 talking to tools and subagents. Do not ask the user to review it.
 
+**Refine the spec before handing it over.** Once the doc changes are written and
+before presenting them, run `remdo-refine` in **working-tree scope** over the
+uncommitted `docs/` edits — so the user reviews already-converged prose, not a
+first draft. This gates only the final handoff: dialog (Phase 2) stays fast and
+unrefined, and the pass runs once here at the gate, not per turn. It is
+working-tree scope because no branch exists yet (created on approval below); it
+commits nothing, and a later rejection still reverts the edits cleanly. The
+precondition above guarantees the tree holds only this spec, so the pass sees
+nothing unrelated.
+
 The user reviews the **`docs/` changes** (the chat message is a thin pointer:
 which docs changed, plus a ~5-bullet approach summary — not the design pasted
 inline). The user does **not** review a detailed plan. This is the only mandatory
@@ -98,12 +116,8 @@ leaves a stray branch). The Phase-3 spec edits do live in the working tree on th
 current branch, though: if the user rejects at the gate, **revert them** before
 exiting — don't leave unapproved `docs/`/`docs/todo.md` changes behind. Confirm
 branch name/prefix (see "Branch naming") and create it per "Branch base" below;
-the approved spec docs are the branch's first commit.
-
-The tree must hold **only this flow's own changes** before that first commit —
-if it had pre-existing unrelated edits when the run started, **stop**: committing
-or branching could sweep them in, and refine later needs a clean tree. The user
-commits, stashes, or sets them aside first.
+the approved spec docs are the branch's first commit (the Phase-3 precondition
+above already ensured the tree holds only this flow's changes).
 
 ## Phase 4 — Autonomous execution
 

--- a/.claude/skills/remdo-refine/SKILL.md
+++ b/.claude/skills/remdo-refine/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: remdo-refine
-description: Use to run the autonomous quality loop over a committed range on the current branch (defaults to `wip-base..HEAD`, accepts an explicit range, clean tree) — simplify, review at max effort, then external Codex review, looping until a clean pass. Triggers include "refine this", "run the refine ladder", "review/simplify/fix loop", or `remdo-feature-flow` calling it after implementation. Commit your work first; it does not review uncommitted changes.
+description: Use to run the autonomous quality loop over a diff on the current branch — simplify, review at max effort, then external Codex review, looping until a clean pass. Works on either a committed range (default `wip-base..HEAD`, or an explicit range, clean tree) or the uncommitted working tree (opt-in, for reviewing changes before committing, such as a feature-flow spec). Triggers include "refine this", "run the refine ladder", "review/simplify/fix loop", "refine the uncommitted changes", or `remdo-feature-flow` calling it.
 ---
 
 # Refine
@@ -23,9 +23,13 @@ below is a judgement, not a tuned number.
 
 ## Scope
 
-Refine works on a single committed range, fixed at invocation — one base, one
-scope, every pass, no committed-vs-uncommitted branching. The range is resolved
-once, deterministically, in this order:
+Refine works on a single diff, fixed at invocation. There are two scopes; pick
+exactly one and keep it for every pass — never review a mix of committed and
+uncommitted changes in one run, which would make the diff under review ambiguous.
+
+### Committed-range scope (default)
+
+The diff is `<base-sha>..HEAD`. Resolved once, deterministically, in this order:
 
 1. An **explicit range/base passed at invocation** wins (e.g. the caller says
    "refine `HEAD~3..HEAD`" or "refine the commit we just made"). Honour it; do
@@ -59,22 +63,39 @@ check), emit a **non-blocking** nudge — "origin/main is newer; consider
 for an explicit range or a non-task branch, where `wip-base` and `remdo-sync` do
 not apply.
 
-**The working tree must be clean.** Staged, unstaged, or untracked changes sit
-outside the resolved range and would be silently unreviewed, so if the tree is dirty,
-**warn and stop** until the work is committed (or stashed). This is why
-`remdo-feature-flow` commits its phase-4 work before invoking refine.
+**The working tree must be clean** in this scope. Staged, unstaged, or untracked
+changes sit outside the resolved range and would be silently unreviewed, so if
+the tree is dirty, **warn and stop** until the work is committed (or stashed).
+This is why `remdo-feature-flow` commits its phase-4 work before invoking refine.
 
 So that each cycle reviews the previous one's result, **commit every applied
 fix** before re-running the ladder — the fix then lands inside the resolved range
 and the tree stays clean for the next pass.
 
+### Working-tree scope (opt-in)
+
+The diff is the **uncommitted changes** (staged + unstaged + untracked), and the
+working tree *is* the artifact — fixes are applied **in place, not committed**.
+Use it to refine changes the user wants to review *before* they enter history —
+most naturally a `remdo-feature-flow` spec at its Phase-3 gate, where the point
+is to vet the uncommitted docs before approval. Enter it only when the caller
+asks for it (e.g. "refine the uncommitted changes" / "refine before I commit");
+it is never the silent default.
+
+In this scope the clean-tree gate is inverted: an **empty** working-tree diff is
+the stop condition (nothing to refine), and a dirty tree is expected. The
+loop-restart property is preserved by re-reading the working tree each cycle
+rather than a committed range; the "commit every fix" rule does **not** apply —
+the user commits once, after their own review. Everything else (ladder order,
+triage, done/stuck) is identical to the committed-range scope.
+
 ## The ladder
 
 Three passes, cheapest and most local first, most independent last. Each reviews
-the same resolved range.
+the same diff under review (the resolved range, or the working-tree changes).
 
 **Run each in-session review pass (1 and 2) as a fresh, context-limited
-subagent** given only the range — the coordinating session's memory of
+subagent** given only the scope — the coordinating session's memory of
 implementing and reviewing the diff would bias it toward parts it thinks it
 cleaned. Pass 3 (codex, a separate process) gets this fresh read for free. The
 coordinating session triages the returned findings and owns the loop.
@@ -88,22 +109,24 @@ coordinating session triages the returned findings and owns the loop.
    where self-containment matters (not a full restatement). Reading the whole
    touched file, not just the diff hunk, is what catches redundancy against
    unchanged upstream text.
-2. **Internal review** — `/code-review` at max effort against the resolved
-   range's base.
-3. **External review** — `codex review --base <range base>` for an independent
-   outside read. Give it **scope only, no review angle** — leading prompt framing
-   defeats the point.
+2. **Internal review** — `/code-review` at max effort against the diff under
+   review (the resolved range's base, or the working-tree changes).
+3. **External review** — `codex review` for an independent outside read:
+   `--base <range base>` in committed-range scope, `--uncommitted` in
+   working-tree scope. Give it **scope only, no review angle** — leading prompt
+   framing defeats the point.
 
 Forward the `AGENTS.md` findings-suppression rule to every pass and subagent.
 
 ## The loop
 
-Each pass produces findings. Triage, apply and **commit** what is approved, then
-**restart from pass 1** — a simplify or internal pass should always see the
-post-fix code first.
+Each pass produces findings. Triage, apply what is approved (committing it in
+committed-range scope; in place in working-tree scope), then **restart from pass
+1** — a simplify or internal pass should always see the post-fix code first.
 
 - **Approved fix** — clearly correct and safe (or an intended change the diff owns).
-  Apply and commit it; the run is not done.
+  Apply it (committed-range: commit; working-tree: leave in the tree); the run is
+  not done.
 - **Tradeoff** — a real choice with no single correct answer. Solve it best-effort
   and **record it in `docs/todo.md`** — a tradeoff is a deferral until a final
   decision is deliberately taken, so the entry persists until then (don't leave it
@@ -125,20 +148,37 @@ which local-agent checks otherwise skip and only CI catches. A failure caused by
 an applied fix re-enters the loop; a pre-existing unrelated failure is reported,
 not fixed here.
 
+`pnpm run lint` is always mandatory (it is fast and `AGENTS.md` requires it
+before handing any task back). What may be narrowed is the heavier work: in
+**local-agent** runs a docs- or skill-only diff (common in working-tree scope,
+e.g. a feature-flow spec) can skip the code test suites and `audit:cleanup`,
+since they exercise nothing the diff touched. **Cloud-agent** runs narrow
+nothing — `AGENTS.md` requires `lint` + `test:unit:full` + `test:collab:full` in
+full regardless of diff content unless the user explicitly skips one.
+
 ## Permissions
 
-Refine commits each fix, so invoking it is an explicitly declared autonomous
-scope (per AGENTS.md): authorization to commit **on the current branch** — never
-push. The dropped task-branch restriction lets it run on `dev` as readily as a
-feature branch, but **`main` stays protected**: if invoked on `main`, warn and
-stop (same guard as the dirty-tree check) rather than self-committing there.
-Inside a `remdo-feature-flow` run, that skill's commit policy already governs.
+In **committed-range** scope refine commits each fix, so invoking it is an
+explicitly declared autonomous scope (per AGENTS.md): authorization to commit
+**on the current branch** — never push. The dropped task-branch restriction lets
+it run on `dev` as readily as a feature branch, but **`main` stays protected**:
+if invoked on `main`, warn and stop (same guard as the dirty-tree check) rather
+than self-committing there. Inside a `remdo-feature-flow` run, that skill's commit
+policy already governs.
+
+In **working-tree** scope refine commits nothing — its boundary is *no commit*,
+not *no clean files*. Applying a finding may require editing a clean companion
+file (e.g. updating `docs/index.md` for a new uncommitted spec page, or adding a
+test for an uncommitted code change); that is fine, since editing uncommitted-by-
+the-end files is the global default anyway. It carries no commit authorization
+and the `main` guard does not apply (it never writes history). The user owns the
+eventual commit.
 
 ## Final report
 
 Index the result, do not re-narrate it: scope and base; cycle count and why the
 loop ended; fixes applied (pointing at files, not prose, noting where in the
-resolved range each finding sat); tradeoffs taken with a pointer to their
+diff each finding sat); tradeoffs taken with a pointer to their
 `docs/todo.md` entries; any blocker with its gathered data; and the final checks
 with pass/fail.
 


### PR DESCRIPTION
… uncommitted review process and branch/commit assumptions in remdo-feature-flow and remdo-refine guidance