### PR TITLE
docs(skills): clarify simplify rung counts attribution — split run an…

### DIFF
--- a/.claude/skills/remdo-refine/SKILL.md
+++ b/.claude/skills/remdo-refine/SKILL.md
@@ -192,7 +192,9 @@ diff each finding sat); tradeoffs taken with a pointer to their
 with pass/fail.
 
 Then one **per-rung counts** line each for simplify / internal / external: how
-many times it ran, findings it surfaced, and findings applied.
+many times it ran, findings it surfaced, and how many of those were applied. For
+the simplify rung, split the run and surfaced counts by tool (`/simplify` vs the
+`remdo-simplify` skill); the applied count is not attributed per tool.
 
 ## References
 


### PR DESCRIPTION
…d surfaced counts by /simplify versus remdo-simplify while keeping applied counts aggregated