### PR TITLE
skills: feature-flow spec-compliance exit gate + refine-hardened follow-ups

### DIFF
--- a/.claude/skills/remdo-feature-flow/SKILL.md
+++ b/.claude/skills/remdo-feature-flow/SKILL.md
@@ -178,11 +178,12 @@ above already ensured the tree holds only this flow's changes).
    branch's `docs/` changes — Phase 3's sense) and the branch diff
    (`origin/main...HEAD` plus any uncommitted work, untracked files included);
    it may read the rest of the repo for cross-checking (except `.agent/`, where
-   the plan lives) but carries neither the plan nor this session's memory. Fix real
-   gaps (the loop continues); document or remove what is built but unspecified
-   (the docs are the target reality); a deliberate deferral goes to
-   `docs/todo.md` (invariant #9). The loop exits when this read comes back clean
-   or fully tracked. For user-facing behavior, also verify the built behavior
+   the plan lives) but carries neither the plan nor this session's memory. The
+   subagent only reports; acting on the report stays with you, inside the loop:
+   fix real gaps (the loop continues), document or remove what is built but
+   unspecified (the docs are the target reality), and record deliberate
+   deferrals in `docs/todo.md` (invariant #9). The loop exits when this read
+   comes back clean or fully tracked. For user-facing behavior, also verify the built behavior
    live per the AGENTS.md DevTools flow, with automated coverage per its e2e
    escalation rule — `superpowers:verification-before-completion` is the
    discipline for this exit step where available.

--- a/.claude/skills/remdo-feature-flow/SKILL.md
+++ b/.claude/skills/remdo-feature-flow/SKILL.md
@@ -37,7 +37,9 @@ Everything else is a thin chat pointer.
 
 The user states the vague idea: what they know, what they are unsure about. No
 structure required. **Verify every fact the user asserts before building on it** —
-never rely on an unchecked user claim. Record what you verified and the outcome
+never rely on an unchecked user claim. Verification reads code, so the Phase-2
+base precondition runs before it — checked facts must describe the state the
+branch will fork from. Record what you verified and the outcome
 in the working artifact at `.agent/plans/<YYYY-MM-DD>-<feature>.md` (see Phase 4),
 so the basis for the design survives beyond this session's memory rather than
 being silently carried.
@@ -45,7 +47,8 @@ being silently carried.
 ## Phase 2 — Dialog
 
 **Precondition — design against the same base the fork will use.** Run this
-**before reading any code or docs below**: the spec must be shaped against exactly
+**before the flow reads any code or docs — Phase-1 fact verification
+included**: the spec must be shaped against exactly
 the state the task branch will fork from, or Phase 2 designs against one codebase
 while Phase 3 branches from another. It must gate the dialog, not just branch
 creation — by Phase 3 the wrong context has already shaped the design.
@@ -168,7 +171,19 @@ above already ensured the tree holds only this flow's changes).
    `superpowers:test-driven-development` for new behavior,
    `superpowers:systematic-debugging` for a bug or unexpected failure — rather
    than writing ad hoc.
-3. **Refine is part of done** — once the gap-closing loop reaches the spec's
+3. **The loop's exit is an independent spec-compliance read, not
+   self-assessment.** When the loop believes the spec's described state is
+   reached, dispatch a **fresh subagent** given only the spec (the branch's
+   `docs/` state) and the branch diff (`origin/main...HEAD` plus any uncommitted
+   work) — not the plan, not this session's memory — to report divergences both
+   ways: specified but not built, and built but not specified. Fix real gaps
+   (the loop continues); a deliberate deferral goes to `docs/todo.md` (invariant
+   #9). The loop exits when this read comes back clean or fully tracked. For
+   user-facing behavior, also verify the built behavior live per the AGENTS.md
+   DevTools flow, with automated coverage per its e2e escalation rule —
+   `superpowers:verification-before-completion` is the discipline for this exit
+   step where available.
+4. **Refine is part of done** — once the gap-closing loop reaches the spec's
    described state, **commit the phase-4 work** (refine and sync both need a clean
    tree; refine reviews the committed `origin/main...HEAD` range). If `origin/main`
    has advanced since branch creation (cheap `git fetch` check), **suggest
@@ -179,7 +194,7 @@ above already ensured the tree holds only this flow's changes).
    findings (defined there, not restated here), and the final checks for the
    current agent mode at the end. Refine converges *code quality*; reaching the
    spec's described state stays the gap-closing loop's job above.
-4. **Mid-work decisions:** small blast radius (a later reversal would not waste
+5. **Mid-work decisions:** small blast radius (a later reversal would not waste
    the work) → use judgment, **record it in `docs/todo.md`**, keep moving.
    Genuine large-blast-radius fork → stop, **recording the fork, the options, and
    what it blocks on in `docs/todo.md`** (not just chat) so the retro and any
@@ -295,14 +310,13 @@ fork base from the design base again. The Phase-2 base check left the current
 branch even with that SHA, so only the **uncommitted spec edits** need to carry
 across:
 
-- Create the branch with `git switch --merge -c <name> --no-track <pinned-base-sha>`.
+- Create the branch with `git switch --merge -c <name> <pinned-base-sha>`.
   `--merge` carries the uncommitted spec edits onto the new base (a plain `git
   switch -c` would **abort and strand the spec** if a spec-touched file differed);
   since the current branch is already at the pinned base, a conflict is not
-  expected. `--no-track` keeps the start point from setting the upstream (a
-  mismatched name that breaks the user's first push under `push.default=simple`);
-  the user's first push then sets the upstream to `origin/<same-name>` (`git push
-  -u origin HEAD`, or automatically with `push.autoSetupRemote`).
+  expected. A raw-SHA start point sets no upstream, so the user's first push sets
+  it to `origin/<same-name>` (`git push -u origin HEAD`, or automatically with
+  `push.autoSetupRemote`).
 
 This flow forks task branches from `origin/main` only. Stacked/dependent branches
 (forking off another in-progress branch) are out of scope — they would make
@@ -339,9 +353,8 @@ Choose by the *activity*, not the phase number:
 
 ## References
 
-- Sequenced skills: `superpowers:brainstorming`,
-  `superpowers:dispatching-parallel-agents`, `superpowers:using-git-worktrees`,
-  `superpowers:verification-before-completion`.
+- Sequenced skills: `superpowers:dispatching-parallel-agents`,
+  `superpowers:using-git-worktrees`, `superpowers:verification-before-completion`.
 - Phase-4 implementation discipline: `superpowers:test-driven-development`,
   `superpowers:systematic-debugging`.
 - Phase-4 quality loop (simplify / internal review / external Codex review):

--- a/.claude/skills/remdo-feature-flow/SKILL.md
+++ b/.claude/skills/remdo-feature-flow/SKILL.md
@@ -33,25 +33,12 @@ changes** (phase 3) and the **report's diff index** (phase 5). Deferrals land in
 `docs/todo.md`. `.agent/` is agent-only scratch, never a review surface.
 Everything else is a thin chat pointer.
 
-## Phase 1 — Draft (user)
+## Preflight — pin the design base
 
-The user states the vague idea: what they know, what they are unsure about. No
-structure required. **Verify every fact the user asserts before building on it** —
-never rely on an unchecked user claim. Verification reads code, so the Phase-2
-base precondition runs before it — checked facts must describe the state the
-branch will fork from. Record what you verified and the outcome
-in the working artifact at `.agent/plans/<YYYY-MM-DD>-<feature>.md` (see Phase 4),
-so the basis for the design survives beyond this session's memory rather than
-being silently carried.
-
-## Phase 2 — Dialog
-
-**Precondition — design against the same base the fork will use.** Run this
-**before the flow reads any code or docs — Phase-1 fact verification
-included**: the spec must be shaped against exactly
-the state the task branch will fork from, or Phase 2 designs against one codebase
-while Phase 3 branches from another. It must gate the dialog, not just branch
-creation — by Phase 3 the wrong context has already shaped the design.
+Run this first, **before the flow reads any code or docs**: fact verification,
+dialog, and the spec must all be shaped against exactly the state the task
+branch will fork from, or the design is built against one codebase while
+Phase 3 branches from another.
 
 1. **Tree clean of unrelated changes first.** Apply the Phase-3 "no unrelated
    changes" check *now*, before the fast-forward below can touch the tree — a
@@ -75,6 +62,17 @@ creation — by Phase 3 the wrong context has already shaped the design.
    the fork point for this run. Phase 3 creates the branch from *this pinned SHA*,
    not a re-fetched `origin/main` — otherwise `origin/main` advancing mid-flow
    would again split the design base from the fork base.
+
+## Phase 1 — Draft (user)
+
+The user states the vague idea: what they know, what they are unsure about. No
+structure required. **Verify every fact the user asserts before building on it** —
+never rely on an unchecked user claim. Record what you verified and the outcome
+in the working artifact at `.agent/plans/<YYYY-MM-DD>-<feature>.md` (see Phase 4),
+so the basis for the design survives beyond this session's memory rather than
+being silently carried.
+
+## Phase 2 — Dialog
 
 Conversation plus cheap checks — inline, interactive, no subagents (latency the
 user feels in real time).
@@ -114,7 +112,7 @@ them — see AGENTS.md). Everything this flow itself produced is fine and expect
 Phase 2 — so a normal clean-start run (where the only changes are this flow's)
 passes this gate; it is not a requirement that "only spec edits" exist.
 
-This gate assumes the **Phase-2 base check ran** (see Phase 2): it left the
+This gate assumes the **preflight base check ran** (see Preflight): it left the
 current branch even with the pinned base SHA and recorded that SHA, which is what
 lets the branch created below fork with no committed work lost and no stale design
 base.
@@ -173,16 +171,18 @@ above already ensured the tree holds only this flow's changes).
    than writing ad hoc.
 3. **The loop's exit is an independent spec-compliance read, not
    self-assessment.** When the loop believes the spec's described state is
-   reached, dispatch a **fresh subagent** given only the spec (the branch's
-   `docs/` state) and the branch diff (`origin/main...HEAD` plus any uncommitted
-   work) — not the plan, not this session's memory — to report divergences both
-   ways: specified but not built, and built but not specified. Fix real gaps
-   (the loop continues); a deliberate deferral goes to `docs/todo.md` (invariant
-   #9). The loop exits when this read comes back clean or fully tracked. For
-   user-facing behavior, also verify the built behavior live per the AGENTS.md
-   DevTools flow, with automated coverage per its e2e escalation rule —
-   `superpowers:verification-before-completion` is the discipline for this exit
-   step where available.
+   reached, dispatch a **fresh subagent** given the spec (the branch's `docs/`
+   changes — Phase 3's sense) and the branch diff (`origin/main...HEAD` plus any
+   uncommitted work), free to read the rest of the repo for cross-checking but
+   carrying neither the plan nor this session's memory, to report divergences
+   both ways: specified but not built, and built but not specified. Fix real
+   gaps (the loop continues); document or remove what is built but unspecified
+   (the docs are the target reality); a deliberate deferral goes to
+   `docs/todo.md` (invariant #9). The loop exits when this read comes back clean
+   or fully tracked. For user-facing behavior, also verify the built behavior
+   live per the AGENTS.md DevTools flow, with automated coverage per its e2e
+   escalation rule — `superpowers:verification-before-completion` is the
+   discipline for this exit step where available.
 4. **Refine is part of done** — once the gap-closing loop reaches the spec's
    described state, **commit the phase-4 work** (refine and sync both need a clean
    tree; refine reviews the committed `origin/main...HEAD` range). If `origin/main`
@@ -269,8 +269,8 @@ a task branch. Within a run:
   `dev` or `main`.
 - **`git fetch`: always allowed** — it only updates remote-tracking refs, never
   your work or the remote.
-- **Fast-forwarding the current branch to `origin/main`** as part of the Phase-2
-  base check: allowed. `git merge --ff-only origin/main` only advances a *behind*
+- **Fast-forwarding the current branch to `origin/main`** as part of the
+  preflight base check: allowed. `git merge --ff-only origin/main` only advances a *behind*
   branch along existing history — no rewrite, no merge commit, nothing lost — so
   it is safe autonomously; it fails (and thus never mutates) on a diverged branch,
   which the base check handles as the *ahead* stop. This is the one exception to
@@ -298,25 +298,23 @@ The single base for every diff, for both user and agent, is the **merge-base of
 
 Always go through the merge-base: it is recomputed from the two refs every time,
 so no base tag is stored and it cannot go stale — it shows exactly this branch's
-own work even after a `remdo-sync` merge moves it forward. (Plain two-dot `git
-diff origin/main` is *not* equivalent — after a merge it diffs against the wrong
-point.) **Default all mid-work and end-of-work diff/review checks to this
-merge-base.**
+own work even after a `remdo-sync` merge moves it forward. (A plain `git diff
+origin/main` is *not* equivalent — once `origin/main` advances past the branch's
+merge-base, it diffs against the wrong point.) **Default all mid-work and
+end-of-work diff/review checks to this merge-base.**
 
-**Creating the branch** (Phase 3) forks from the **base SHA pinned at Phase 2**
-(step 3 there) — the exact state the spec was designed against — *not* a freshly
-re-fetched `origin/main`, which may have advanced mid-flow and would split the
-fork base from the design base again. The Phase-2 base check left the current
-branch even with that SHA, so only the **uncommitted spec edits** need to carry
-across:
+**Creating the branch** (Phase 3) forks from the **base SHA pinned at
+preflight** (step 3 there) — the exact state the spec was designed against —
+*not* a freshly re-fetched `origin/main`, which may have advanced mid-flow and
+would split the fork base from the design base again. The preflight base check
+left the current branch even with that SHA, so only the **uncommitted spec
+edits** need to carry across:
 
 - Create the branch with `git switch --merge -c <name> <pinned-base-sha>`.
   `--merge` carries the uncommitted spec edits onto the new base (a plain `git
   switch -c` would **abort and strand the spec** if a spec-touched file differed);
   since the current branch is already at the pinned base, a conflict is not
-  expected. A raw-SHA start point sets no upstream, so the user's first push sets
-  it to `origin/<same-name>` (`git push -u origin HEAD`, or automatically with
-  `push.autoSetupRemote`).
+  expected.
 
 This flow forks task branches from `origin/main` only. Stacked/dependent branches
 (forking off another in-progress branch) are out of scope — they would make

--- a/.claude/skills/remdo-feature-flow/SKILL.md
+++ b/.claude/skills/remdo-feature-flow/SKILL.md
@@ -173,7 +173,8 @@ above already ensured the tree holds only this flow's changes).
    self-assessment.** When the loop believes the spec's described state is
    reached, dispatch a **fresh subagent** given the spec (the branch's `docs/`
    changes — Phase 3's sense) and the branch diff (`origin/main...HEAD` plus any
-   uncommitted work), free to read the rest of the repo for cross-checking but
+   uncommitted work, untracked files included), free to read the rest of the
+   repo for cross-checking (except `.agent/`, where the plan lives) but
    carrying neither the plan nor this session's memory, to report divergences
    both ways: specified but not built, and built but not specified. Fix real
    gaps (the loop continues); document or remove what is built but unspecified
@@ -294,7 +295,9 @@ The single base for every diff, for both user and agent, is the **merge-base of
   merge-base) — and `codex review --base origin/main` (safe as a one-shot; a
   looping `remdo-refine` pass anchors to a fixed base SHA instead, see that skill).
 - **Working tree included** (committed + uncommitted — the mid-work review loop):
-  `git diff "$(git merge-base origin/main HEAD)"`.
+  `git diff "$(git merge-base origin/main HEAD)"`, plus
+  `git ls-files --others --exclude-standard` for the untracked files that diff
+  omits.
 
 Always go through the merge-base: it is recomputed from the two refs every time,
 so no base tag is stored and it cannot go stale — it shows exactly this branch's
@@ -337,7 +340,9 @@ Choose by the *activity*, not the phase number:
 - **Autonomous execution (phase 4) and Research spikes: subagent-eligible** —
   your call by the independence test: dispatch subagents only for genuinely
   parallel, independent chunks (no shared state, no sequential dependency); stay
-  inline otherwise. Deferred to runtime because the input (the actual dependency
+  inline otherwise. (The Phase-4 exit read is outside this call — its step
+  mandates the fresh-subagent dispatch for memory isolation.) Deferred to
+  runtime because the input (the actual dependency
   graph) does not exist until then. Research spikes are subagent-eligible even
   when triggered from dialog, because the spike itself is autonomous work, not
   conversation.

--- a/.claude/skills/remdo-feature-flow/SKILL.md
+++ b/.claude/skills/remdo-feature-flow/SKILL.md
@@ -43,7 +43,7 @@ Phase 3 branches from another.
 1. **Tree clean of unrelated changes first.** Apply the Phase-3 "no unrelated
    changes" check *now*, before the fast-forward below can touch the tree — a
    fast-forward would otherwise silently advance a checkout the run should have
-   stopped on. Pre-existing unrelated edits → stop (as in Phase 3).
+   stopped on. Pre-existing unrelated edits → stop.
 2. `git fetch`, then compare the current branch (usually `dev`) to `origin/main`:
    - **Ahead** (`git rev-list origin/main..HEAD` non-empty) — the branch holds
      committed work not yet in `origin/main`. The fork carries only the
@@ -54,7 +54,9 @@ Phase 3 branches from another.
    - **Behind** (`git rev-list HEAD..origin/main` non-empty, and *not* also
      ahead) — merely stale. **Fast-forward to `origin/main`** (`git merge
      --ff-only origin/main`); safe (no rewrite, no merge commit, nothing lost) and
-     makes the design base match the fork base.
+     makes the design base match the fork base. If the FF refuses because
+     flow-owned dirty files were also touched upstream, stop and surface it (as
+     for *ahead*).
    - **Diverged** (both ahead and behind) — FF is impossible; treat as *ahead* and
      stop.
    - **Even** — proceed.
@@ -171,12 +173,12 @@ above already ensured the tree holds only this flow's changes).
    than writing ad hoc.
 3. **The loop's exit is an independent spec-compliance read, not
    self-assessment.** When the loop believes the spec's described state is
-   reached, dispatch a **fresh subagent** given the spec (the branch's `docs/`
-   changes — Phase 3's sense) and the branch diff (`origin/main...HEAD` plus any
-   uncommitted work, untracked files included), free to read the rest of the
-   repo for cross-checking (except `.agent/`, where the plan lives) but
-   carrying neither the plan nor this session's memory, to report divergences
-   both ways: specified but not built, and built but not specified. Fix real
+   reached, dispatch a **fresh subagent** to report divergences both ways:
+   specified but not built, and built but not specified. Give it the spec (the
+   branch's `docs/` changes — Phase 3's sense) and the branch diff
+   (`origin/main...HEAD` plus any uncommitted work, untracked files included);
+   it may read the rest of the repo for cross-checking (except `.agent/`, where
+   the plan lives) but carries neither the plan nor this session's memory. Fix real
    gaps (the loop continues); document or remove what is built but unspecified
    (the docs are the target reality); a deliberate deferral goes to
    `docs/todo.md` (invariant #9). The loop exits when this read comes back clean
@@ -307,17 +309,14 @@ merge-base, it diffs against the wrong point.) **Default all mid-work and
 end-of-work diff/review checks to this merge-base.**
 
 **Creating the branch** (Phase 3) forks from the **base SHA pinned at
-preflight** (step 3 there) — the exact state the spec was designed against —
-*not* a freshly re-fetched `origin/main`, which may have advanced mid-flow and
-would split the fork base from the design base again. The preflight base check
-left the current branch even with that SHA, so only the **uncommitted spec
-edits** need to carry across:
-
-- Create the branch with `git switch --merge -c <name> <pinned-base-sha>`.
-  `--merge` carries the uncommitted spec edits onto the new base (a plain `git
-  switch -c` would **abort and strand the spec** if a spec-touched file differed);
-  since the current branch is already at the pinned base, a conflict is not
-  expected.
+preflight** (step 3 there — the pin is what keeps the fork base equal to the
+design base). The preflight base check left the current branch even with that
+SHA, so only the **uncommitted spec edits** need to carry across. Create the
+branch with `git switch --merge -c <name> <pinned-base-sha>`. `--merge` carries
+the spec edits onto the new base (with drift, a plain `git switch -c` would
+**abort and strand the spec**, and `--merge` itself refuses *staged* edits —
+clear the drift rather than un-staging); since the current branch is already at
+the pinned base, neither is expected.
 
 This flow forks task branches from `origin/main` only. Stacked/dependent branches
 (forking off another in-progress branch) are out of scope — they would make
@@ -340,10 +339,10 @@ Choose by the *activity*, not the phase number:
 - **Autonomous execution (phase 4) and Research spikes: subagent-eligible** —
   your call by the independence test: dispatch subagents only for genuinely
   parallel, independent chunks (no shared state, no sequential dependency); stay
-  inline otherwise. (The Phase-4 exit read is outside this call — its step
-  mandates the fresh-subagent dispatch for memory isolation.) Deferred to
-  runtime because the input (the actual dependency
-  graph) does not exist until then. Research spikes are subagent-eligible even
+  inline otherwise. Deferred to runtime because the input (the actual dependency
+  graph) does not exist until then. (A step that itself mandates a dispatch —
+  the Phase-4 exit read — is outside this call.) Research spikes are
+  subagent-eligible even
   when triggered from dialog, because the spike itself is autonomous work, not
   conversation.
 

--- a/.claude/skills/remdo-refine/SKILL.md
+++ b/.claude/skills/remdo-refine/SKILL.md
@@ -193,9 +193,7 @@ diff each finding sat); tradeoffs taken with a pointer to their
 with pass/fail.
 
 Then one **per-rung counts** line each for simplify / internal / external: how
-many times it ran, findings it surfaced, and how many of those were applied. For
-the simplify rung, split the run and surfaced counts by tool (`/simplify` vs the
-`remdo-simplify` skill); the applied count is not attributed per tool.
+many times it ran, findings it surfaced, and how many of those were applied.
 
 ## References
 

--- a/.codex/skills/remdo-simplify/SKILL.md
+++ b/.codex/skills/remdo-simplify/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: remdo-simplify
-description: Use only when explicitly requested — e.g. "run a simplify review", "find simplifications", "what could be simpler here", or a `remdo-refine`-style loop calling for its read-only simplify finder. Runs a read-only RemDo simplification review over a selected diff, reporting code, test, and documentation opportunities to make the end state shorter, simpler, and cleaner, including limited redesign of directly related existing code when that reduces net complexity. Does not edit files, stage, commit, or run mutating checks.
+description: The read-only simplification finder that `remdo-refine` runs as its first rung; invoke directly only for an explicitly requested one-off simplify review (e.g. "run a simplify review", "what could be simpler here"). Reports code, test, and documentation opportunities to make a selected diff's end state shorter, simpler, and cleaner, including limited redesign of directly related existing code when that reduces net complexity. Does not edit files, stage, commit, or run mutating checks.
 context: fork
 agent: Explore
 ---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,6 +187,11 @@ would constrain a future run that may do it better. When unsure, state the inten
 and trust the running model to meet it (mirrors `docs/principles.md`: current
 code does not define the long-term shape).
 
+Voice: write procedure as second-person imperative addressed to the executing
+agent; state invariants, definitions, and permissions declaratively. The
+executing agent is the default "you" — the moment a second actor is in scope (a
+subagent, the user), name the actor of every instruction explicitly.
+
 ## Agent mode
 
 Determine agent mode in this order:


### PR DESCRIPTION
Batch 2 from the skills review, refined to convergence with the new (batch-1) `remdo-refine` loop before opening this PR.

**Intent of the changes:**
- **Feature-flow's "done" stops being self-graded.** The gap-closing loop now exits through an independent spec-compliance read — a fresh subagent, handed the spec (the Phase-3 docs delta) and the branch diff, reports divergences both ways (specified-but-not-built / built-but-unspecified, the latter resolved document-or-remove). Live verification for user-facing behavior is wired in via the AGENTS.md DevTools flow, which also turns the previously dangling `superpowers:verification-before-completion` reference into a sequenced one (and drops the never-sequenced `brainstorming` reference).
- **The base check becomes a real preflight.** It ran mid-file (inside Phase 2) while Phase-1 fact verification already read code against a possibly-stale base; it's now an explicit Preflight section ahead of Phase 1, deleting the cross-reference patches instead of accumulating them.
- **remdo-simplify's description leads with its actual role** (refine's finder rung; direct invocation stays the explicit-request path), and refine's report section drops a stale `/simplify` count split left over from the batch-1 ladder change (a cross-merge leftover between PR #350 and #351).
- **Empirically-verified git precision.** Every command claim in the branch-creation/preflight text was scratch-repo-tested during the refine run; the vestigial `--no-track` is gone, the plain-diff divergence trigger is now stated correctly, and two real refusal edge cases (ff-only vs flow-owned dirty files touched upstream; `--merge` vs staged edits under drift) are mapped instead of implied impossible.

**Refine run (per the request to run it on the finished work):** committed-range scope anchored at `ad9b183`; three rung-2 rounds (10 finder angles + adversarial verification each) + the forked read-only simplify rung; 12 verified findings applied across the last three commits, ~25 candidates refuted or rejected in verification; rung 3 (`codex review`) skipped — CLI absent in this environment, per the ladder's degradation rule. Deviations, reported honestly: the round-2 gap sweep died on a session limit (round 1's sweep + the confirmation cycle cover it), and the confirmation cycle's finder outputs were triaged directly by the coordinator instead of a fourth verifier wave (survivors were multiply-corroborated, self-demonstrated, or previously adjudicated).

Checks: `pnpm run lint` ✅ · `pnpm run test:unit:full` ✅ (876) · `pnpm run test:collab:full` ✅ (921) · `pnpm run audit:cleanup` ⚠️ environmental failure only — `knip`'s pnpm subprocess wants a `/home/user/remdo/.pnpmfile.mjs` that has never existed in the repo (container tooling issue, unrelated to this markdown-only diff; runs fine where pnpm isn't wrapped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rTJHF8fh98PLxEysJ4B61

---
_Generated by [Claude Code](https://claude.ai/code/session_017rTJHF8fh98PLxEysJ4B61)_