### PR TITLE
docs(agents): add local skills reporting requirements — document coor…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,19 @@ sections to docs.
   exploration, fresh review, verification, Research spikes, or required
   fresh-context reads. Keep mutating subagents isolated in worktrees per the
   rules above.
+- When a user prompt causes a repo-local skill under `.agents/skills/` to run,
+  the coordinating interactive agent tracks one local-skills report for that
+  prompt across nested skill calls and subagents. Notice only skill bugs or
+  improvement opportunities hit while doing the requested work: ambiguous or
+  stale instructions, missing dependencies, repeated friction or loops,
+  misleading output, or avoidable runtime cost. Do not run a separate skill
+  audit, spawn monitoring-only subagents, or add timing probes. Ask any skill
+  subagents to include incidental skill-monitor notes in their final answer to
+  the coordinator; the coordinator dedupes them and owns the user-facing report.
+  At the very end of the final response, print at most one `Local skills:` line,
+  and only when a repo-local skill was actually used. Include skill names/counts,
+  timing only when it was already known cheaply from the run, and either `clean`
+  or concise issue/opportunity notes.
 - Assign a unique `PORT_BASE` per worktree (for example `5100`, `5200`) to
   avoid collisions across dev servers, tests, and collab services.
 - Treat each repo/worktree as owning a 100-port block starting at its assigned

--- a/tests/e2e/docker/_support/helpers.ts
+++ b/tests/e2e/docker/_support/helpers.ts
@@ -7,12 +7,16 @@ import { STABLE_AUTH_USERS } from '#tools/stable-auth-users';
 export const DOCKER_TEST_AUTH = STABLE_AUTH_USERS.bob;
 export const DOCKER_TEST_ADMIN_SECRET = config.env.ADMIN_SECRET;
 
+export function allowTransientTokenFetchConsoleIssue(page: Page): void {
+  setExpectedConsoleIssues(page, ['Failed to get client token'], { mode: 'allowContains' });
+}
+
 export async function waitForServiceWorkerControl(page: Page): Promise<void> {
   await page.waitForFunction(() => 'serviceWorker' in navigator);
   await page.evaluate(async () => {
     await navigator.serviceWorker.ready;
   });
-  setExpectedConsoleIssues(page, ['Failed to get client token'], { mode: 'allowContains' });
+  allowTransientTokenFetchConsoleIssue(page);
   await page.reload();
   await page.waitForFunction(() => navigator.serviceWorker.controller !== null);
 }

--- a/tests/e2e/docker/setup.spec.ts
+++ b/tests/e2e/docker/setup.spec.ts
@@ -6,6 +6,7 @@ import { createUserDocument } from '../_support/documents';
 import {
   DOCKER_TEST_ADMIN_SECRET,
   DOCKER_TEST_AUTH,
+  allowTransientTokenFetchConsoleIssue,
   waitForEditableEditor,
   waitForServiceWorkerControl,
 } from './_support/helpers';
@@ -27,6 +28,7 @@ test('admin self-enrollment creates the first admin and can open the editor', as
   await expect(page).toHaveURL(/\/admin$/u);
   await expect(page.getByRole('link', { name: 'Admin' })).toBeVisible();
 
+  allowTransientTokenFetchConsoleIssue(page);
   await page.goto('/home');
   await page.waitForURL(/\/n\//u);
   await waitForEditableEditor(page);


### PR DESCRIPTION
…dinator expectations when prompts trigger .agents skills