### PR TITLE
fix(editor): sync zoom root before key handling — prevent backspace r…

### DIFF
--- a/src/client/editor/features/zoom/ZoomPlugin.tsx
+++ b/src/client/editor/features/zoom/ZoomPlugin.tsx
@@ -73,6 +73,12 @@ export function ZoomPlugin() {
         if ($placeCaretAtZoomEntry(noteId) === 'missing') {
           return false;
         }
+        // Publish the new zoom root synchronously: the React effects that
+        // normally maintain it land only after the next commit, and a keypress
+        // in between (e.g. Backspace right after a bullet click) must already
+        // see the new boundary.
+        zoomNoteIdRef.current = resolveZoomNoteId(noteId);
+        setZoomRoot(editor, $findNoteById(noteId)?.getKey() ?? null);
         requestZoomNoteId(noteId);
         editor.focus();
         return true;

--- a/src/client/editor/features/zoom/ZoomPlugin.tsx
+++ b/src/client/editor/features/zoom/ZoomPlugin.tsx
@@ -70,16 +70,17 @@ export function ZoomPlugin() {
           editor.focus();
           return true;
         }
-        if ($placeCaretAtZoomEntry(noteId) === 'missing') {
+        const zoomRoot = $findNoteById(noteId);
+        if (!zoomRoot || $placeCaretAtZoomEntry(noteId) === 'missing') {
           return false;
         }
+        requestZoomNoteId(noteId);
         // Publish the new zoom root synchronously: the React effects that
         // normally maintain it land only after the next commit, and a keypress
         // in between (e.g. Backspace right after a bullet click) must already
         // see the new boundary.
         zoomNoteIdRef.current = resolveZoomNoteId(noteId);
-        setZoomRoot(editor, $findNoteById(noteId)?.getKey() ?? null);
-        requestZoomNoteId(noteId);
+        setZoomRoot(editor, zoomRoot.getKey());
         editor.focus();
         return true;
       },

--- a/src/client/editor/view/EditorViewProvider.tsx
+++ b/src/client/editor/view/EditorViewProvider.tsx
@@ -6,7 +6,6 @@ import type { SearchableNotes } from '#client/editor/search/search-candidates';
 
 export interface EditorViewBindings {
   zoomNoteId?: string | null;
-  onZoomNoteIdChange?: (noteId: string | null) => void;
 }
 
 /** Runs `fn` against the live editor's SDK notes inside an editor read. Returns
@@ -35,7 +34,11 @@ export function EditorViewProvider({
   docId,
   zoomNoteId = null,
   onZoomNoteIdChange,
-}: EditorViewBindings & { children: ReactNode; docId: string }) {
+}: EditorViewBindings & {
+  children: ReactNode;
+  docId: string;
+  onZoomNoteIdChange: (noteId: string | null) => void;
+}) {
   const [zoomPathState, setZoomPathState] = useState({
     sourceDocId: docId,
     path: EMPTY_PATH,
@@ -59,7 +62,7 @@ export function EditorViewProvider({
   }, [docId]);
 
   const requestZoomNoteId = useCallback((noteId: string | null) => {
-    onZoomNoteIdChangeRef.current?.(noteId);
+    onZoomNoteIdChangeRef.current(noteId);
   }, []);
 
   // The editor (inside the composer) registers a reader bound to its live state;

--- a/tests/e2e/editor/zoom-visibility.spec.ts
+++ b/tests/e2e/editor/zoom-visibility.spec.ts
@@ -324,10 +324,12 @@ test.describe('Zoom visibility', () => {
 
     const editorRoot = editorLocator(page);
     const note2Text = editorRoot.locator('[data-lexical-text="true"]', { hasText: 'note2' }).first();
+    const note2 = note2Text.locator('xpath=ancestor::li[contains(@class, "list-item")][1]');
     const metrics = await getBulletMetrics(note2Text);
 
     await page.mouse.click(metrics.x, metrics.y);
     await expect(page).toHaveURL(createEditorDocumentPathRegExp(editor.docId, 'note2'));
+    await expect(note2).toHaveAttribute('data-zoom-root', 'true');
 
     await setCaretAtText(page, 'note2', 0);
     await page.keyboard.press('Control+A');

--- a/tests/unit/_support/test-resource.ts
+++ b/tests/unit/_support/test-resource.ts
@@ -7,16 +7,21 @@ interface TestResource {
 export function createTestResource<TOptions, TResource extends TestResource>(
   createResource: (options?: TOptions) => TResource,
 ): (options?: TOptions) => TResource {
-  let currentResource: TResource | null = null;
+  let resources: TResource[] = [];
 
   afterEach(async () => {
-    await currentResource?.cleanup();
-    currentResource = null;
+    // Every resource is cleaned up here, awaited — a fire-and-forget cleanup
+    // when a test creates a second resource races the rest of the test.
+    const pending = resources;
+    resources = [];
+    for (const resource of pending) {
+      await resource.cleanup();
+    }
   });
 
   return (options?: TOptions) => {
-    void currentResource?.cleanup();
-    currentResource = createResource(options);
-    return currentResource;
+    const resource = createResource(options);
+    resources.push(resource);
+    return resource;
   };
 }

--- a/tests/unit/_support/timeouts.ts
+++ b/tests/unit/_support/timeouts.ts
@@ -1,4 +1,8 @@
 export const VITEST_DEFAULT_TEST_TIMEOUT_MS = 5000;
+// For specs whose tests spawn pnpm/tsx subprocesses: the cold start alone is
+// 1-2s per spawn and multiplies under full-suite fork contention, so the
+// default budget flakes on loaded machines.
+export const SUBPROCESS_TEST_TIMEOUT_MS = 15_000;
 export const TESTING_LIBRARY_ASYNC_TIMEOUT_MS = Math.floor(
   VITEST_DEFAULT_TEST_TIMEOUT_MS * 0.4,
 );

--- a/tests/unit/collab/_support/render-editor.tsx
+++ b/tests/unit/collab/_support/render-editor.tsx
@@ -1,11 +1,10 @@
 import { MantineProvider } from '@mantine/core';
 import { render } from '@testing-library/react';
-import Editor from '#client/editor/Editor';
 import type { RemdoTestApi } from '#client/editor/plugins/dev';
 import { getTestBridgeRegistry } from '#client/editor/plugins/dev/testBridgeRegistry';
-import { EditorViewProvider } from '#client/editor/view/EditorViewProvider';
 import type { EditorViewBindings } from '#client/editor/view/EditorViewProvider';
 import { ensureCollabTestDocument } from './documents';
+import { TestEditorView } from './test-editor-view';
 
 /**
  * Renders the RemDo editor for tests and resolves its remdoTest bridge.
@@ -27,9 +26,7 @@ export async function renderRemdoEditor(
 
   const { unmount } = render(
     <MantineProvider>
-      <EditorViewProvider docId={docId} {...viewProps}>
-        <Editor docId={docId} statusPortalRoot={null} />
-      </EditorViewProvider>
+      <TestEditorView docId={docId} viewProps={viewProps} />
     </MantineProvider>
   );
 

--- a/tests/unit/collab/_support/test-editor-view.tsx
+++ b/tests/unit/collab/_support/test-editor-view.tsx
@@ -1,0 +1,31 @@
+import { useCallback, useState } from 'react';
+import Editor from '#client/editor/Editor';
+import { EditorViewProvider } from '#client/editor/view/EditorViewProvider';
+import type { EditorViewBindings } from '#client/editor/view/EditorViewProvider';
+
+export function TestEditorView({
+  docId,
+  viewProps = {},
+}: {
+  docId: string;
+  viewProps?: EditorViewBindings;
+}) {
+  const controlledZoomNoteId = viewProps.zoomNoteId;
+  const [requestedZoomNoteId, setRequestedZoomNoteId] = useState<string | null>(null);
+  const zoomNoteId = controlledZoomNoteId === undefined ? requestedZoomNoteId : controlledZoomNoteId;
+  const handleZoomNoteIdChange = useCallback((nextZoomNoteId: string | null) => {
+    if (controlledZoomNoteId === undefined) {
+      setRequestedZoomNoteId(nextZoomNoteId);
+    }
+  }, [controlledZoomNoteId]);
+
+  return (
+    <EditorViewProvider
+      docId={docId}
+      onZoomNoteIdChange={handleZoomNoteIdChange}
+      zoomNoteId={zoomNoteId}
+    >
+      <Editor docId={docId} statusPortalRoot={null} />
+    </EditorViewProvider>
+  );
+}

--- a/tests/unit/collab/snapshot.collab.spec.ts
+++ b/tests/unit/collab/snapshot.collab.spec.ts
@@ -51,28 +51,31 @@ describe('snapshot CLI', { timeout: COLLAB_LONG_TIMEOUT_MS }, () => {
   it(
     'saves the current editor state via snapshot CLI',
     meta({ collabDocId: 'snapshotFlat', fixture: 'flat' }),
-    async () => {
+    async ({ remdo }: TestContext) => {
       const docId = 'snapshotFlat';
 
       const savePath = snapshotOutputPath('snapshot.cli.flat.json');
       const expectedState = readEditorState(path.resolve('tests/fixtures/flat.json'));
+      await remdo.waitForSynced();
+
       await waitFor(() => {
         runSnapshotSave(['--doc', docId, savePath]);
         const saved = stripEditorStateDefaults(readEditorState(savePath));
-        return JSON.stringify(saved.root) === JSON.stringify(expectedState.root);
+        expect(saved.root).toEqual(expectedState.root);
       });
     }
   );
 
-  it('resolves the document id from the CLI flag', meta({ collabDocId: 'cliFlag', fixture: 'basic' }), async () => {
+  it('resolves the document id from the CLI flag', meta({ collabDocId: 'cliFlag', fixture: 'basic' }), async ({ remdo }: TestContext) => {
     const docId = 'cliFlag';
     const expected = readEditorState(path.resolve('tests/fixtures/basic.json'));
     const savePath = snapshotOutputPath(`${docId}.json`);
+    await remdo.waitForSynced();
 
     await waitFor(() => {
       runSnapshotSave(['--doc', docId, savePath]);
       const saved = stripEditorStateDefaults(readEditorState(savePath));
-      return JSON.stringify(saved) === JSON.stringify(expected);
+      expect(saved).toEqual(expected);
     });
   });
 

--- a/tests/unit/collab/token-acquisition.collab.spec.tsx
+++ b/tests/unit/collab/token-acquisition.collab.spec.tsx
@@ -1,12 +1,11 @@
 import { MantineProvider } from '@mantine/core';
 import { render } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import Editor from '#client/editor/Editor';
-import { EditorViewProvider } from '#client/editor/view/EditorViewProvider';
 import { createDocumentSyncTokenApiPath } from '#document-routes';
 import { getCollabTestSessionCookie, withSessionCookie } from './_support/auth';
 import { ensureCollabTestDocument } from './_support/documents';
 import { renderRemdoEditor } from './_support/render-editor';
+import { TestEditorView } from './_support/test-editor-view';
 import { COLLAB_LONG_TIMEOUT_MS } from './_support/timeouts';
 
 interface RecordedRequest {
@@ -84,9 +83,7 @@ describe('collaboration token acquisition', { timeout: COLLAB_LONG_TIMEOUT_MS },
 
     const { unmount } = render(
       <MantineProvider>
-        <EditorViewProvider docId={docId}>
-          <Editor docId={docId} statusPortalRoot={null} />
-        </EditorViewProvider>
+        <TestEditorView docId={docId} />
       </MantineProvider>
     );
 
@@ -135,9 +132,7 @@ describe('collaboration token acquisition', { timeout: COLLAB_LONG_TIMEOUT_MS },
 
     const { unmount } = render(
       <MantineProvider>
-        <EditorViewProvider docId={docId}>
-          <Editor docId={docId} statusPortalRoot={null} />
-        </EditorViewProvider>
+        <TestEditorView docId={docId} />
       </MantineProvider>
     );
 

--- a/tests/unit/deletion.spec.ts
+++ b/tests/unit/deletion.spec.ts
@@ -1,4 +1,4 @@
-import { waitFor } from '@testing-library/react';
+import { act, waitFor } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import { $getNodeByKey, $getSelection, $isRangeSelection, REDO_COMMAND, UNDO_COMMAND } from 'lexical';
 import type { TextNode } from 'lexical';
@@ -17,6 +17,7 @@ import {
   meta,
 } from '#tests';
 import { $findNoteById } from '#client/editor/outline/note-traversal';
+import { ZOOM_TO_NOTE_COMMAND } from '#client/editor/commands';
 
 // Coverage gaps (handled in e2e instead of unit tests):
 // - Inline Backspace/Delete inside a note: jsdom doesn’t emulate native deletion
@@ -52,6 +53,25 @@ describe('deletion semantics (docs/outliner/deletion.md)', () => {
       await placeCaretAtNote(remdo, 'note2', 0);
 
       await pressKey(remdo, { key: 'Backspace' });
+
+      expect(remdo).toMatchEditorState(before);
+      expect(remdo).toMatchSelection({ state: 'caret', note: 'note2' });
+    });
+
+    it('backspace racing the zoom command still respects the new zoom boundary', meta({ fixture: 'flat' }), async ({ remdo }) => {
+      await placeCaretAtNote(remdo, 'note2', 0);
+      const before = remdo.getEditorState();
+
+      // Zoom command and keydown in one act block: the keypress lands before
+      // React commits the zoom effects, like a fast keypress right after a
+      // bullet click. The boundary guard must already see the new zoom root.
+      const root = remdo.editor.getRootElement()!;
+      await act(async () => {
+        remdo.editor.dispatchCommand(ZOOM_TO_NOTE_COMMAND, { noteId: 'note2' });
+        root.dispatchEvent(
+          new KeyboardEvent('keydown', { key: 'Backspace', bubbles: true, cancelable: true }),
+        );
+      });
 
       expect(remdo).toMatchEditorState(before);
       expect(remdo).toMatchSelection({ state: 'caret', note: 'note2' });

--- a/tests/unit/server/_support/server-app-harness.ts
+++ b/tests/unit/server/_support/server-app-harness.ts
@@ -1,6 +1,3 @@
-import fs from 'node:fs';
-import os from 'node:os';
-import path from 'node:path';
 import { deriveAuthTrustedOrigins } from '#config/env/auth-origins';
 import { createServerApp } from '#server/app';
 import {
@@ -46,9 +43,10 @@ export function createServerAppHarness({
   onUpdateDoc?: (docId: string, update: Uint8Array) => void | Promise<void>;
   logError?: ServerDiagnosticReporter;
 } = {}) {
-  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'remdo-server-auth-'));
-  const dbPath = path.join(tempDir, 'remdo.sqlite');
-  const client = createServerDatabaseClient({ dbPath });
+  // In-memory like the other server harnesses — a per-test on-disk DB fsyncs
+  // on every DDL/write, which turns contended-CI disk latency into test and
+  // teardown timeouts.
+  const client = createServerDatabaseClient({ dbPath: ':memory:' });
   // Derive trusted origins from the harness's own baseURL (not the env singleton)
   // so the auth instance honours the baseURL it was given.
   const trustedOrigins = deriveAuthTrustedOrigins({
@@ -213,7 +211,6 @@ export function createServerAppHarness({
     async cleanup() {
       await auth.ensureReady();
       await client.close();
-      fs.rmSync(tempDir, { recursive: true, force: true });
     },
   };
 }

--- a/tests/unit/server/ensure-source-client.spec.ts
+++ b/tests/unit/server/ensure-source-client.spec.ts
@@ -1,6 +1,3 @@
-import fs from 'node:fs';
-import os from 'node:os';
-import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createServerDatabaseClient } from '#server/db/client';
 import type { SqliteServerDatabaseClient } from '#server/db/client';
@@ -9,17 +6,14 @@ import { deriveSourceId } from '#server/remdo-oauth/config';
 import { ensureSourceServerRow, readSourceServersSync } from '#server/remdo-oauth/source-server-store';
 
 describe('ensureSourceClient', () => {
-  let dir: string;
   let database: SqliteServerDatabaseClient;
 
   beforeEach(() => {
-    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'remdo-ensure-source-client-'));
-    database = createServerDatabaseClient({ dbPath: path.join(dir, 'remdo.sqlite') });
+    database = createServerDatabaseClient({ dbPath: ':memory:' });
   });
 
   afterEach(async () => {
     await database.close();
-    fs.rmSync(dir, { recursive: true, force: true });
   });
 
   it('registers and caches a public client on first link to a source origin', async () => {

--- a/tests/unit/server/source-server-store.spec.ts
+++ b/tests/unit/server/source-server-store.spec.ts
@@ -1,6 +1,3 @@
-import fs from 'node:fs';
-import os from 'node:os';
-import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { createServerDatabaseClient } from '#server/db/client';
 import type { SqliteServerDatabaseClient } from '#server/db/client';
@@ -14,17 +11,14 @@ import {
 const SOURCE_ID = deriveSourceId('https://source.example');
 
 describe('source server store', () => {
-  let dir: string;
   let database: SqliteServerDatabaseClient;
 
   beforeEach(() => {
-    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'remdo-source-store-'));
-    database = createServerDatabaseClient({ dbPath: path.join(dir, 'remdo.sqlite') });
+    database = createServerDatabaseClient({ dbPath: ':memory:' });
   });
 
   afterEach(async () => {
     await database.close();
-    fs.rmSync(dir, { recursive: true, force: true });
   });
 
   it('starts empty', async () => {

--- a/tests/unit/snapshot-backup.spec.ts
+++ b/tests/unit/snapshot-backup.spec.ts
@@ -5,6 +5,7 @@ import os from 'node:os';
 import path from 'node:path';
 import process from 'node:process';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { SUBPROCESS_TEST_TIMEOUT_MS } from './_support/timeouts';
 
 const STALE_STAGING_STARTED_AT = Date.now() - (31 * 60 * 1000);
 
@@ -53,7 +54,7 @@ function runBackup(dataDir: string, args: string[] = []): ReturnType<typeof spaw
   );
 }
 
-describe('snapshot backup CLI', () => {
+describe('snapshot backup CLI', { timeout: SUBPROCESS_TEST_TIMEOUT_MS }, () => {
   let tempDirs: string[] = [];
 
   beforeEach(() => {


### PR DESCRIPTION
…ace and stabilize tests with awaited resource cleanup, longer subprocess timeout, and in-memory sqlite server DBs