### PR TITLE
chore(ci): increase collab workflow timeout and compute test timeout …

### DIFF
--- a/.github/workflows/collab-tests.yml
+++ b/.github/workflows/collab-tests.yml
@@ -9,13 +9,12 @@ jobs:
     permissions:
       contents: read
       actions: write
-    timeout-minutes: 5
+    # Leave one minute for setup and cleanup after the test deadline.
+    timeout-minutes: 8
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-pnpm
 
       - name: Run collaboration unit tests
-        env:
-          TEST_TIMEOUT: 270
-        run: pnpm run test:collab:full
+        run: TEST_TIMEOUT=$((60 * 7)) pnpm run test:collab:full


### PR DESCRIPTION
…— bump job limit to 8 minutes and pass TEST_TIMEOUT as 7 minutes via inline shell expression