### PR TITLE
chore(config): prune obsolete ignore and tune watch exclusions — remo…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,8 +21,6 @@ Thumbs.db
 
 # per-working-dir agent scratch (plans, mid-task notes); never versioned
 /.agent/
-# subagent-driven-development scratch (briefs, reports, ledger); never versioned
-/.superpowers/
 
 # generated playground explorers, served by the dev server over HTTP
 /public/playground/

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -82,6 +82,15 @@
     "verbatimModuleSyntax": true,
     "skipLibCheck": true
   },
+  "watchOptions": {
+    "excludeDirectories": [
+      "./data",
+      "./dist",
+      "./coverage",
+      "./.agent",
+      "./public/playground"
+    ]
+  },
   "include": [
     "./**/*",
     // TS globs skip dot-directories; skill-local tools/tests need an explicit


### PR DESCRIPTION
…ve .superpowers from gitignore and add tsconfig watch excludeDirectories for build artifacts and local data paths