### PR TITLE
docs(specs): refine agent doc contracts — update runner scope, merge …

### DIFF
--- a/docs/specs/agents/tools/read-only-runner.md
+++ b/docs/specs/agents/tools/read-only-runner.md
@@ -30,10 +30,8 @@ leaves absent values unset, so the agent applies its own default.
 **Prompt.** The runner passes the prompt to the agent's non-interactive session
 unchanged.
 
-**Review.** The runner gives each agent's native review the resolved scope:
-`uncommitted` covers every staged, unstaged, and untracked changed path and
-nothing from committed branch history, and `commit-range` covers `base` through
-the commit `HEAD` names when the invocation begins.
+**Review.** The runner gives each agent's native review the complete resolved
+scope.
 
 A review uses the native command's instructions and the repository guidance its
 session loads. The runner additionally instructs the reviewing agent and every

--- a/docs/specs/feedback-cases/README.md
+++ b/docs/specs/feedback-cases/README.md
@@ -2,8 +2,8 @@
 
 This directory records non-normative feedback cases about how RemDo
 specifications are written. This README defines how that evidence is structured
-and maintained. The evidence does not define accepted behavior or documentation
-rules.
+and maintained. The evidence does not define accepted behavior or
+[documentation rules](../../documentation.md).
 
 A **feedback case** preserves evidence for later specification research and
 testing. `Post-change` is the version considered a better fit for the recorded

--- a/docs/specs/outliner/list-types.md
+++ b/docs/specs/outliner/list-types.md
@@ -1,9 +1,10 @@
 # List types
 
 This specification defines the outliner's supported list types, list-type
-conversion, and the checked state of notes, including how checked-state changes
-resolve their targets. Selection kinds and note ranges are defined by
-[Selection](../../outliner/selection.md).
+conversion, and the checked state of
+[notes](../../outliner/concepts.md#core-idea-note-concept), including how
+checked-state changes resolve their targets. Selection kinds and note ranges are
+defined by [Selection](../../outliner/selection.md).
 
 ## Supported types
 

--- a/docs/specs/outliner/reordering.md
+++ b/docs/specs/outliner/reordering.md
@@ -1,7 +1,7 @@
 # Reordering
 
 This specification defines keyboard-driven reordering of target note ranges,
-including directional movement, subtree integrity, zoom boundaries, and no-op
+including directional movement, order preservation, zoom boundaries, and no-op
 behavior. Selection kinds and note ranges are defined by
 [Selection](../../outliner/selection.md).
 
@@ -15,8 +15,8 @@ A caret or inline text selection targets the
 [editor note](../../outliner/concepts.md#note-kinds) that owns its region as a
 one-note target range. A structural selection targets its selected note range.
 
-Reordering preserves the notes' document order and moves each note with its
-entire subtree.
+Reordering preserves the notes' [document
+order](../../outliner/concepts.md#definitions).
 
 ## Directional movement
 

--- a/docs/specs/skills/remdo-merge-main.md
+++ b/docs/specs/skills/remdo-merge-main.md
@@ -5,6 +5,13 @@ result. Requested local work may be preserved; unrelated branch convergence
 and remote mutation are outside the capability. Concurrent repository mutation
 and recovery from an interrupted run are also outside the capability.
 
+## Authority
+
+The skill declares the [autonomous
+scope](../../../AGENTS.md#safety--process) for the branch update, merge and
+correction commits, and determined conflict resolutions. Preserve mode also
+covers saving and restoring local work.
+
 ## Target
 
 The run fetches remote `main` from `origin` and fixes the fetched commit as its
@@ -40,19 +47,12 @@ the Git merge state for manual recovery.
 ## Verification
 
 An up-to-date or fast-forward result requires no repository check. A merge
-commit requires `pnpm run check:full`.
+commit requires the [full repository check](../../../AGENTS.md#checks).
 
 When verification fails, the capability commits every determined correction
 caused by integrating the target, then runs complete verification again. An
 unrelated failure or one without a determined integration correction remains in
 the result without rolling back the merge.
-
-## Authority
-
-The skill declares the [autonomous
-scope](../../../AGENTS.md#safety--process) for the branch update, merge and
-correction commits, and determined conflict resolutions. Preserve mode also
-covers saving and restoring local work.
 
 ## Result
 

--- a/docs/specs/skills/remdo-verify-change.md
+++ b/docs/specs/skills/remdo-verify-change.md
@@ -26,13 +26,15 @@ until verification finishes.
               └─> [Claude review] ─┴─> [finding validation] ─> [report]
 ```
 
-The verifier runs applicable deterministic repository checks in place.
+The verifier runs the [repository checks prescribed for the agent mode and
+scope](../../../AGENTS.md#checks) in place.
 
 ## Reviews
 
 The verifier invokes the [read-only
 runner](../agents/tools/read-only-runner.md#call) independently for Codex and
-Claude with a `review` invocation, the resolved change scope, and `high` effort.
+Claude with a `review` invocation and the resolved change scope. Their
+identities remain distinct in the result.
 For Claude, the verifier exercises the caller judgement required by the runner's
 [trusted-prompt level](../agents/tools/read-only-runner.md#trusted-prompt): it
 judges the runner-constructed vendor-owned native review command and its
@@ -75,6 +77,18 @@ expand the selected scope or decide what happens next.
 
 ## Result
 
+`clean` means checks passed, finding validation completed, and it produced only
+`rejected` dispositions or no findings. `findings` means completed validation
+produced a `confirmed`, `unresolved`, or `material out of scope` disposition.
+`no-change` means scope resolution found no diff, so checks and reviews were not
+run. `stopped` means scope resolution, checks, or finding validation prevented
+completion. `degraded` accompanies the status when an attempted reviewer was
+unavailable or failed; neither condition alone changes `clean` to `findings`.
+
+A failed step reports only evidence relevant to its failure, not its successful
+sub-results. Reviews intentionally not attempted are `not run`, not
+`unavailable`.
+
 The result follows this order:
 
 ```text
@@ -105,15 +119,3 @@ none
 or
 <disposition, finding, and reason>
 ```
-
-`clean` means checks passed, finding validation completed, and it produced only
-`rejected` dispositions or no findings. `findings` means completed validation
-produced a `confirmed`, `unresolved`, or `material out of scope` disposition.
-`no-change` means scope resolution found no diff, so checks and reviews were not
-run. `stopped` means scope resolution, checks, or finding validation prevented
-completion. `degraded` accompanies the status when an attempted reviewer was
-unavailable or failed; neither condition alone changes `clean` to `findings`.
-
-A failed step reports only evidence relevant to its failure, not its successful
-sub-results. Reviews intentionally not attempted are `not run`, not
-`unavailable`.


### PR DESCRIPTION
…and verify spec wording with links and status definitions