### PR TITLE
fix(read-only-runner): simplify Claude parsing and preserve raw evide…

### DIFF
--- a/.agents/skills/_shared/tests/read-only-runner.spec.ts
+++ b/.agents/skills/_shared/tests/read-only-runner.spec.ts
@@ -662,6 +662,11 @@ describe('read-only runner CLI', () => {
       body: "printf '   \\n'",
       retained: '   \n',
     },
+    {
+      case: 'output without a final newline',
+      body: "printf %s 'not-json'",
+      retained: 'not-json',
+    },
   ])('retains $case verbatim in review failure evidence', ({ body, retained }) => {
     const work = makeBareMain({ 'tracked.md': 'tracked\n' });
     writeFile(work, 'tracked.md', 'changed\n');
@@ -822,6 +827,30 @@ describe('read-only runner CLI', () => {
       + 'provider transcript\n',
     );
     expect(result.stderr).not.toContain('provider stdout');
+  });
+
+  it.each([
+    {
+      case: 'without a final newline',
+      body: 'printf %s "provider transcript" >&2',
+      retained: 'provider transcript',
+    },
+    {
+      case: 'when it is whitespace-only',
+      body: "printf '   \\n' >&2",
+      retained: '   \n',
+    },
+  ])('preserves provider stderr $case', ({ body, retained }) => {
+    const work = makeBareMain({ 'tracked.md': 'tracked\n' });
+    const stub = claudeStub([body, 'exit 7']);
+
+    const result = runRunner(work, ['claude', 'prompt', 'Inspect.'], stub);
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toBe(
+      `read-only-runner: Claude failed with status 7\n${retained}`,
+    );
   });
 
   it('captures stderr from a failed Codex invocation', () => {

--- a/.agents/skills/_shared/tests/read-only-runner.spec.ts
+++ b/.agents/skills/_shared/tests/read-only-runner.spec.ts
@@ -62,33 +62,6 @@ function claudeResult(result: unknown, overrides: Record<string, unknown> = {}):
   });
 }
 
-function claudeStream(...events: unknown[]): string {
-  return `printf '%s\\n' ${
-    events.map(event => shellLiteral(JSON.stringify(event))).join(' ')
-  }`;
-}
-
-function claudeReviewResult(
-  result: unknown,
-  slashCommands: unknown = ['/code-review'],
-  overrides: Record<string, unknown> = {},
-): string {
-  return claudeStream(
-    {
-      type: 'system',
-      subtype: 'init',
-      slash_commands: slashCommands,
-    },
-    {
-      type: 'result',
-      subtype: 'success',
-      is_error: false,
-      result,
-      ...overrides,
-    },
-  );
-}
-
 function providerEnvironment(
   stub: string,
   overrides: NodeJS.ProcessEnv = {},
@@ -474,7 +447,7 @@ describe('read-only runner CLI', () => {
       'printf \'%s\\n\' "$GIT_CONFIG_COUNT" "$GIT_CONFIG_KEY_0" "$GIT_CONFIG_VALUE_0" > "$RUNNER_STUB_CAPTURE/git-env"',
       'printf \'%s\' "$CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS" > "$RUNNER_STUB_CAPTURE/background-wait"',
       'printf \'%s\' "$CLAUDE_CODE_REPORT_FINDINGS" > "$RUNNER_STUB_CAPTURE/report-findings"',
-      claudeReviewResult('No findings.'),
+      claudeResult('No findings.'),
     ]);
 
     const result = runRunner(
@@ -513,9 +486,8 @@ describe('read-only runner CLI', () => {
       'explicitly instruct every delegated reviewer not to run repository checks',
     );
     expect(argv).not.toContain('--append-subagent-system-prompt');
-    expect(argv).toContain('stream-json');
-    expect(argv).toContain('--verbose');
-    expect(argv).not.toContain('json');
+    expect(argumentAfter(argv, '--output-format')).toBe('json');
+    expect(argv).not.toContain('stream-json');
     expect(argv).not.toContain('--json-schema');
     expect(
       fs.readFileSync(path.join(stub, 'background-wait'), 'utf8'),
@@ -549,7 +521,7 @@ describe('read-only runner CLI', () => {
     writeFile(work, 'line\nbreak.md', 'untracked\n');
     const stub = claudeStub([
       'printf \'%s\\n\' "$@" > "$RUNNER_STUB_CAPTURE/args"',
-      claudeReviewResult('No findings.'),
+      claudeResult('No findings.'),
     ]);
 
     const result = runRunner(
@@ -573,7 +545,7 @@ describe('read-only runner CLI', () => {
         'untracked\n',
       );
     }
-    const stub = claudeStub([claudeReviewResult('No findings.')]);
+    const stub = claudeStub([claudeResult('No findings.')]);
 
     const result = runRunner(
       work,
@@ -607,7 +579,7 @@ describe('read-only runner CLI', () => {
     writeFile(work, 'candidate.md', 'staged\n');
     git(work, 'add', 'candidate.md');
     writeFile(work, 'candidate.md', 'base\n');
-    const stub = claudeStub([claudeReviewResult('No findings.')]);
+    const stub = claudeStub([claudeResult('No findings.')]);
 
     const result = runRunner(
       work,
@@ -626,7 +598,7 @@ describe('read-only runner CLI', () => {
     const head = git(work, 'rev-parse', 'HEAD').stdout.trim();
     const stub = claudeStub([
       'printf \'%s\\n\' "$@" > "$RUNNER_STUB_CAPTURE/args"',
-      claudeReviewResult('Range clean.'),
+      claudeResult('Range clean.'),
     ]);
 
     const result = runRunner(
@@ -641,39 +613,32 @@ describe('read-only runner CLI', () => {
     );
   });
 
-  it('classifies Claude review availability from init instead of result prose', () => {
-    const work = makeBareMain({ 'tracked.md': 'tracked\n' });
-    writeFile(work, 'tracked.md', 'changed\n');
-    const unavailableStub = claudeStub([
-      claudeReviewResult('', []),
-    ]);
-    const availableStub = claudeStub([
-      claudeReviewResult('Unknown command: /code-review'),
-    ]);
-
-    const unavailable = runRunner(
-      work,
-      ['claude', 'review', 'uncommitted'],
-      unavailableStub,
-    );
-    const response = runRunner(
-      work,
-      ['claude', 'review', 'uncommitted'],
-      availableStub,
-    );
-
-    expect(unavailable.status).toBe(2);
-    expect(unavailable.stdout).toBe('');
-    expect(unavailable.stderr).toContain('/code-review is unavailable');
-    expect(response.status).toBe(0);
-    expect(response.stdout).toBe('Unknown command: /code-review');
-  });
-
-  it('accepts the unprefixed Claude command emitted by the current CLI', () => {
+  // A review reporting the command name is the review's own finding: the
+  // runner has no signal distinguishing that from an absent command.
+  it('keeps a review that reports the command name as a finding', () => {
     const work = makeBareMain({ 'tracked.md': 'tracked\n' });
     writeFile(work, 'tracked.md', 'changed\n');
     const stub = claudeStub([
-      claudeReviewResult('No findings.', ['code-review']),
+      claudeResult('Unknown command: /code-review'),
+    ]);
+
+    const result = runRunner(
+      work,
+      ['claude', 'review', 'uncommitted'],
+      stub,
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe('Unknown command: /code-review');
+  });
+
+  // A delegating review reports no turns of its own, so the turn count does
+  // not distinguish a completed review from an unresolved command.
+  it('keeps a delegated review report that took no turn', () => {
+    const work = makeBareMain({ 'tracked.md': 'tracked\n' });
+    writeFile(work, 'tracked.md', 'changed\n');
+    const stub = claudeStub([
+      claudeResult('No findings.', { num_turns: 0 }),
     ]);
 
     const result = runRunner(
@@ -686,44 +651,39 @@ describe('read-only runner CLI', () => {
     expect(result.stdout).toBe('No findings.');
   });
 
-  it('uses the first init and terminal top-level result in a delegated review stream', () => {
+  it.each([
+    {
+      case: 'a leading BOM',
+      body: "printf '\\357\\273\\277%s\\n' '{}'",
+      retained: '\u{FEFF}{}\n',
+    },
+    {
+      case: 'whitespace-only output',
+      body: "printf '   \\n'",
+      retained: '   \n',
+    },
+  ])('retains $case verbatim in review failure evidence', ({ body, retained }) => {
     const work = makeBareMain({ 'tracked.md': 'tracked\n' });
     writeFile(work, 'tracked.md', 'changed\n');
-    const init = {
-      type: 'system',
-      subtype: 'init',
-      slash_commands: ['code-review'],
-    };
+    const stub = claudeStub([body]);
+
+    const result = runRunner(work, ['claude', 'review', 'uncommitted'], stub);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('could not parse Claude result');
+    // The bytes that explain the parse failure survive into the evidence.
+    expect(result.stderr.toString().endsWith(`\n${retained}`)).toBe(true);
+  });
+
+  it('takes the review report from the single-result output format', () => {
+    const work = makeBareMain({ 'tracked.md': 'tracked\n' });
+    writeFile(work, 'tracked.md', 'changed\n');
+    // The delegating review emits several results across sessions plus
+    // trailing task events. The report comes from the provider's single-result
+    // format, so the runner never selects among stream events.
     const stub = claudeStub([
-      claudeStream(
-        init,
-        {
-          type: 'result',
-          subtype: 'success',
-          is_error: false,
-          result: 'Delegated result.',
-          parent_tool_use_id: 'delegated-review',
-        },
-        init,
-        {
-          type: 'system',
-          subtype: 'task_notification',
-          task_id: 'reviewer',
-        },
-        {
-          type: 'result',
-          subtype: 'success',
-          is_error: false,
-          result: 'Late delegated result.',
-          parent_tool_use_id: 'late-delegated-review',
-        },
-        {
-          type: 'result',
-          subtype: 'success',
-          is_error: false,
-          result: 'Final result.',
-        },
-      ),
+      'printf \'%s\\n\' "$@" > "$RUNNER_STUB_CAPTURE/args"',
+      claudeResult('Final result.'),
     ]);
 
     const result = runRunner(
@@ -734,95 +694,53 @@ describe('read-only runner CLI', () => {
 
     expect(result.status).toBe(0);
     expect(result.stdout).toBe('Final result.');
+    const argv = fs.readFileSync(path.join(stub, 'args'), 'utf8')
+      .trimEnd()
+      .split('\n');
+    expect(argumentAfter(argv, '--output-format')).toBe('json');
+    expect(argv).not.toContain('--verbose');
   });
 
+  // Every unusable report keeps the provider output that explains it, on both
+  // invocation kinds, which share one handler.
   it.each([
     {
       body: "printf '%s\\n' 'not-json'",
-      evidence: 'could not parse Claude stream line 1',
+      evidence: 'could not parse Claude result',
+      retained: 'not-json',
     },
     {
-      body: claudeResult('No init.'),
-      evidence: 'did not include an init event',
-    },
-    {
-      body: claudeReviewResult('Invalid commands.', 'code-review'),
-      evidence: 'did not include a valid slash command list',
-    },
-    {
-      body: `printf '%s\\n' ${
-        shellLiteral(JSON.stringify({
-          type: 'system',
-          subtype: 'init',
-          slash_commands: ['code-review'],
-        }))
-      }`,
-      evidence: 'did not end with a top-level result event',
-    },
-    {
-      body: claudeStream(
-        {
-          type: 'system',
-          subtype: 'init',
-          slash_commands: ['code-review'],
-        },
-        {
-          type: 'result',
-          subtype: 'success',
-          is_error: false,
-          result: 'Premature result.',
-        },
-        {
-          type: 'system',
-          subtype: 'task_notification',
-          task_id: 'reviewer',
-        },
-      ),
-      evidence: 'did not end with a top-level result event',
-    },
-    {
-      body: claudeStream(
-        {
-          type: 'system',
-          subtype: 'init',
-          slash_commands: ['code-review'],
-        },
-        {
-          type: 'result',
-          subtype: 'success',
-          is_error: false,
-          result: 'Delegated result.',
-          parent_tool_use_id: 'delegated-review',
-        },
-      ),
-      evidence: 'did not end with a top-level result event',
-    },
-    {
-      body: claudeReviewResult('Failed.', ['/code-review'], {
+      body: claudeResult('Failed.', {
         subtype: 'error_during_execution',
         is_error: true,
       }),
       evidence: 'did not return a successful result envelope',
+      retained: 'error_during_execution',
     },
     {
-      body: claudeReviewResult(' \n\t'),
+      body: claudeResult(' \n\t'),
       evidence: 'completed without a final text response',
+      retained: '"type":"result"',
     },
-  ])('rejects an invalid Claude review stream: $evidence', ({ body, evidence }) => {
-    const work = makeBareMain({ 'tracked.md': 'tracked\n' });
-    writeFile(work, 'tracked.md', 'changed\n');
-    const stub = claudeStub([body]);
+  ])(
+    'rejects an unusable Claude report retaining its output: $evidence',
+    ({ body, evidence, retained }) => {
+      const work = makeBareMain({ 'tracked.md': 'tracked\n' });
+      writeFile(work, 'tracked.md', 'changed\n');
 
-    const result = runRunner(
-      work,
-      ['claude', 'review', 'uncommitted'],
-      stub,
-    );
+      for (const args of [
+        ['claude', 'review', 'uncommitted'],
+        ['claude', 'prompt', 'Inspect.'],
+      ]) {
+        const result = runRunner(work, args, claudeStub([body]));
 
-    expect(result.status).toBe(1);
-    expect(result.stdout).toBe('');
-    expect(result.stderr).toContain(evidence);
-  });
+        expect(result.status).toBe(1);
+        expect(result.stdout).toBe('');
+        expect(result.stderr).toContain(evidence);
+        expect(result.stderr).toContain(retained);
+      }
+    },
+  );
 
   it.each([
     {
@@ -964,6 +882,35 @@ describe('read-only runner CLI', () => {
     expect(whitespaceResult.stderr).toContain(
       'Codex completed without a final response',
     );
+  });
+
+  it('retains Codex output as evidence when no report is produced', () => {
+    const work = makeBareMain({ 'tracked.md': 'tracked\n' });
+    const stub = codexStub(["printf '%s\\n' 'diagnostic explaining the failure'"]);
+
+    const result = runRunner(work, ['codex', 'prompt', 'Inspect.'], stub);
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toContain('Codex completed without a final response');
+    expect(result.stderr).toContain('diagnostic explaining the failure');
+  });
+
+  it('reports a Codex final-response read failure with provider output', () => {
+    const work = makeBareMain({ 'tracked.md': 'tracked\n' });
+    const stub = reportWritingCodex('', [
+      'mkdir "$report"',
+      "printf '%s\\n' 'diagnostic explaining the read failure'",
+      'exit 0',
+    ]);
+
+    const result = runRunner(work, ['codex', 'prompt', 'Inspect.'], stub);
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toContain('could not read Codex final response');
+    expect(result.stderr).toContain('EISDIR');
+    expect(result.stderr).toContain('diagnostic explaining the read failure');
   });
 
   it('loads its runtime and allocates private output outside an external repository', () => {

--- a/.agents/skills/_shared/tools/read-only-runner.ts
+++ b/.agents/skills/_shared/tools/read-only-runner.ts
@@ -210,6 +210,13 @@ function providerFailureEvidence(summary: string, stderr: string): string {
   return stderr.trim() === '' ? summary : `${summary}\n${stderr}`;
 }
 
+// Retains provider output exactly, so evidence still reproduces a failure
+// caused by bytes an emptiness test would otherwise strip. Only genuinely
+// absent output is omitted.
+function outputEvidence(summary: string, stdout: string): string {
+  return stdout === '' ? summary : `${summary}\n${stdout}`;
+}
+
 function providerFailure(
   provider: Agent,
   outcome: ProcessOutcome,
@@ -582,19 +589,29 @@ async function runCodex(
   if (failure !== undefined) {
     return failure;
   }
-  let response: string;
+  let response = '';
   try {
     response = await fs.readFile(reportPath, 'utf8');
-  } catch {
-    return {
-      status: 'failed',
-      evidence: 'Codex completed without a final response',
-    };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      return {
+        status: 'failed',
+        evidence: outputEvidence(
+          `could not read Codex final response: ${String(error)}`,
+          outcome.stdout,
+        ),
+      };
+    }
+    // The report is the response; its absence is reported below with whatever
+    // the invocation printed instead.
   }
   if (response.trim() === '') {
     return {
       status: 'failed',
-      evidence: 'Codex completed without a final response',
+      evidence: outputEvidence(
+        'Codex completed without a final response',
+        outcome.stdout,
+      ),
     };
   }
   return { status: 'responded', response };
@@ -728,11 +745,8 @@ function claudeInvocation(
     '--mcp-config',
     '{"mcpServers":{}}',
     '--output-format',
-    review ? 'stream-json' : 'json',
+    'json',
   );
-  if (review) {
-    args.push('--verbose');
-  }
   if (call.settings.model !== undefined) {
     args.push('--model', call.settings.model);
   }
@@ -778,97 +792,22 @@ function claudeResult(envelope: Record<string, unknown>): RunnerResult {
   return { status: 'responded', response: envelope.result };
 }
 
-function claudePromptResult(stdout: string): RunnerResult {
-  let envelope: Record<string, unknown>;
+function claudeOutputResult(stdout: string): RunnerResult {
+  const failed = (summary: string): RunnerResult => ({
+    status: 'failed',
+    evidence: outputEvidence(summary, stdout),
+  });
+  let envelope: unknown;
   try {
-    const parsed: unknown = JSON.parse(stdout);
-    if (!isObject(parsed)) {
-      return {
-        status: 'failed',
-        evidence: 'Claude output was not a JSON object',
-      };
-    }
-    envelope = parsed;
+    envelope = JSON.parse(stdout);
   } catch (error) {
-    return {
-      status: 'failed',
-      evidence: `could not parse Claude result: ${String(error)}`,
-    };
+    return failed(`could not parse Claude result: ${String(error)}`);
   }
-  return claudeResult(envelope);
-}
-
-function claudeReviewResult(stdout: string): RunnerResult {
-  const lines = stdout.split(/\r?\n/u).filter(line => line.trim() !== '');
-  let initEvent: Record<string, unknown> | undefined;
-  let finalEvent: Record<string, unknown> | undefined;
-  for (const [index, line] of lines.entries()) {
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(line);
-    } catch (error) {
-      return {
-        status: 'failed',
-        evidence: `could not parse Claude stream line ${index + 1}: ${String(error)}`,
-      };
-    }
-    if (!isObject(parsed)) {
-      return {
-        status: 'failed',
-        evidence: `Claude stream line ${index + 1} was not a JSON object`,
-      };
-    }
-    if (
-      initEvent === undefined
-      && parsed.type === 'system'
-      && parsed.subtype === 'init'
-    ) {
-      initEvent = parsed;
-    }
-    finalEvent = parsed;
+  if (!isObject(envelope)) {
+    return failed('Claude output was not a JSON object');
   }
-
-  if (initEvent === undefined) {
-    return {
-      status: 'failed',
-      evidence: 'Claude review stream did not include an init event',
-    };
-  }
-  const slashCommands = initEvent.slash_commands;
-  if (
-    !Array.isArray(slashCommands)
-    || !slashCommands.every(command => typeof command === 'string')
-  ) {
-    return {
-      status: 'failed',
-      evidence: 'Claude init event did not include a valid slash command list',
-    };
-  }
-  if (
-    !slashCommands.some(command =>
-      command === CLAUDE_REVIEW_COMMAND
-      || command === CLAUDE_REVIEW_COMMAND.slice(1),
-    )
-  ) {
-    return {
-      status: 'unavailable',
-      evidence: `${CLAUDE_REVIEW_COMMAND} is unavailable in this Claude session`,
-    };
-  }
-
-  if (
-    finalEvent?.type !== 'result'
-    || (
-      finalEvent.parent_tool_use_id !== undefined
-      && finalEvent.parent_tool_use_id !== null
-    )
-  ) {
-    return {
-      status: 'failed',
-      evidence: 'Claude review stream did not end with a top-level result event',
-    };
-  }
-  return claudeResult(finalEvent);
+  const result = claudeResult(envelope);
+  return result.status === 'failed' ? failed(result.evidence) : result;
 }
 
 async function runClaude(
@@ -925,13 +864,8 @@ async function runClaude(
     input: invocation.input,
     signal,
   });
-  const failure = providerFailure('claude', outcome);
-  if (failure !== undefined) {
-    return failure;
-  }
-  return call.invocation.kind === 'review'
-    ? claudeReviewResult(outcome.stdout)
-    : claudePromptResult(outcome.stdout);
+  return providerFailure('claude', outcome)
+    ?? claudeOutputResult(outcome.stdout);
 }
 
 async function run(

--- a/.agents/skills/_shared/tools/read-only-runner.ts
+++ b/.agents/skills/_shared/tools/read-only-runner.ts
@@ -23,9 +23,9 @@ interface RunnerCall {
 }
 
 type RunnerResult =
-  | { status: 'failed'; evidence: string }
+  | { status: 'failed'; evidence: string; preserveEvidenceEnd?: boolean }
   | { status: 'responded'; response: string }
-  | { status: 'unavailable'; evidence: string };
+  | { status: 'unavailable'; evidence: string; preserveEvidenceEnd?: boolean };
 
 interface ProcessOutcome {
   aborted: boolean;
@@ -206,15 +206,23 @@ function runProcess(
   });
 }
 
-function providerFailureEvidence(summary: string, stderr: string): string {
-  return stderr.trim() === '' ? summary : `${summary}\n${stderr}`;
+// Retains provider output exactly, including its final byte. Only genuinely
+// absent output is omitted.
+function outputEvidence(
+  summary: string,
+  output: string,
+): { evidence: string; preserveEvidenceEnd: boolean } {
+  return {
+    evidence: output === '' ? summary : `${summary}\n${output}`,
+    preserveEvidenceEnd: output !== '',
+  };
 }
 
-// Retains provider output exactly, so evidence still reproduces a failure
-// caused by bytes an emptiness test would otherwise strip. Only genuinely
-// absent output is omitted.
-function outputEvidence(summary: string, stdout: string): string {
-  return stdout === '' ? summary : `${summary}\n${stdout}`;
+function outputFailure(
+  summary: string,
+  stdout: string,
+): Extract<RunnerResult, { status: 'failed' }> {
+  return { status: 'failed', ...outputEvidence(summary, stdout) };
 }
 
 function providerFailure(
@@ -225,7 +233,7 @@ function providerFailure(
   if (outcome.spawnError?.code === 'ENOENT') {
     return {
       status: 'unavailable',
-      evidence: providerFailureEvidence(
+      ...outputEvidence(
         `${name} executable is unavailable`,
         outcome.stderr,
       ),
@@ -234,7 +242,7 @@ function providerFailure(
   if (outcome.spawnError !== undefined) {
     return {
       status: 'failed',
-      evidence: providerFailureEvidence(
+      ...outputEvidence(
         `${name} could not start: ${outcome.spawnError.message}`,
         outcome.stderr,
       ),
@@ -243,7 +251,7 @@ function providerFailure(
   if (outcome.aborted) {
     return {
       status: 'failed',
-      evidence: providerFailureEvidence(
+      ...outputEvidence(
         `${name} was cancelled`,
         outcome.stderr,
       ),
@@ -252,7 +260,7 @@ function providerFailure(
   if (outcome.exitCode !== 0) {
     return {
       status: 'failed',
-      evidence: providerFailureEvidence(
+      ...outputEvidence(
         `${name} failed with status ${
           outcome.exitCode ?? `signal ${outcome.signal ?? 'unknown'}`
         }`,
@@ -374,7 +382,7 @@ async function probeCodexReview(
   if (outcome.exitCode !== 0) {
     return {
       status: 'unavailable',
-      evidence: providerFailureEvidence(
+      ...outputEvidence(
         'Codex native review is unavailable',
         outcome.stderr,
       ),
@@ -594,25 +602,19 @@ async function runCodex(
     response = await fs.readFile(reportPath, 'utf8');
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
-      return {
-        status: 'failed',
-        evidence: outputEvidence(
-          `could not read Codex final response: ${String(error)}`,
-          outcome.stdout,
-        ),
-      };
+      return outputFailure(
+        `could not read Codex final response: ${String(error)}`,
+        outcome.stdout,
+      );
     }
     // The report is the response; its absence is reported below with whatever
     // the invocation printed instead.
   }
   if (response.trim() === '') {
-    return {
-      status: 'failed',
-      evidence: outputEvidence(
-        'Codex completed without a final response',
-        outcome.stdout,
-      ),
-    };
+    return outputFailure(
+      'Codex completed without a final response',
+      outcome.stdout,
+    );
   }
   return { status: 'responded', response };
 }
@@ -793,10 +795,8 @@ function claudeResult(envelope: Record<string, unknown>): RunnerResult {
 }
 
 function claudeOutputResult(stdout: string): RunnerResult {
-  const failed = (summary: string): RunnerResult => ({
-    status: 'failed',
-    evidence: outputEvidence(summary, stdout),
-  });
+  const failed = (summary: string): RunnerResult =>
+    outputFailure(summary, stdout);
   let envelope: unknown;
   try {
     envelope = JSON.parse(stdout);
@@ -926,7 +926,10 @@ async function main(): Promise<void> {
       return;
     }
     process.stderr.write(`read-only-runner: ${result.evidence}`);
-    if (!result.evidence.endsWith('\n')) {
+    if (
+      result.preserveEvidenceEnd !== true
+      && !result.evidence.endsWith('\n')
+    ) {
       process.stderr.write('\n');
     }
     process.exitCode = result.status === 'unavailable' ? 2 : 1;

--- a/docs/specs/agents/tools/read-only-runner.md
+++ b/docs/specs/agents/tools/read-only-runner.md
@@ -88,8 +88,8 @@ A result is encoded by the runner's exit status and output:
 
 - `responded`: exit `0` and write only the non-empty complete final text to
   stdout;
-- `unavailable`: exit `2` and write evidence that the agent CLI or requested
-  native capability is unavailable to stderr;
+- `unavailable`: exit `2` and write evidence that the agent CLI or a requested
+  native capability the runner can establish is unavailable to stderr;
 - `failed`: any other non-zero exit and failure evidence on stderr.
 
 Only `responded` writes stdout. It confirms transport and response integrity,
@@ -97,6 +97,16 @@ not that the response satisfies the caller's task; the caller owns that
 validation. When a provider process exits unsuccessfully, its failure evidence
 includes any non-empty provider stderr verbatim after the runner-owned summary;
 provider stdout is not failure evidence.
+
+A provider reports an unresolved native review command as a successful response
+saying the command is unknown, which the runner cannot distinguish from a review
+reporting that text. A `responded` review therefore does not establish that a
+review ran; the caller judges the report.
+
+When a provider exits successfully but its output does not yield a complete
+report, the failure evidence includes that output verbatim after the
+runner-owned summary, so the caller can diagnose an unrecognized protocol shape
+from the failure alone.
 
 ## Empirical checks
 
@@ -118,6 +128,14 @@ provider stdout is not failure evidence.
 
 - Enforce Claude invocations without adding host requirements to trusted review
   sessions.
+- Confirm the provider protocols the runner depends on against the installed
+  CLIs rather than against runner-authored stubs alone, so a provider change
+  fails a check instead of silently changing what callers receive. Weigh this
+  against a check that needs provider credentials and network access.
+- Establish that a Claude native review command is absent, so the runner reports
+  it as unavailable instead of leaving the caller to judge the report. The
+  session inventory is the only documented signal and requires a separate
+  session per review; weigh that cost against the caller's own judgement.
 
 ## References
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -107,13 +107,6 @@ Remove rejected or obsolete items and empty sections.
 
 ### Agents
 
-- **Claude review stream completion.** The read-only runner assumes Claude's
-  `/code-review` stream ends with one authoritative top-level result, but Claude
-  Code 2.1.220 emitted multiple parentless results plus trailing task events:
-  one run rejected completed review output and another accepted an incremental
-  fragment. Identify the coordinator's complete report, retain raw stream
-  evidence on failure, and cover the observed stream shape.
-
 - **External dependency verification.** Define how implementation work checks
   current authoritative documentation or public APIs for external dependencies
   before using [empirical checks](documentation.md#empirical-checks).


### PR DESCRIPTION
…nce — switch to json-only parsing, drop stream-based review heuristics, and retain provider stdout in failure diagnostics