### PR TITLE
chore(agents): move skill specs and links under docs/specs/agents/ski…

### DIFF
--- a/.agents/skills/remdo-converge-change/SKILL.md
+++ b/.agents/skills/remdo-converge-change/SKILL.md
@@ -6,7 +6,7 @@ description: Converge a default or explicitly selected RemDo uncommitted or Git-
 # RemDo Converge Change
 
 Converge one scope under the authoritative
-[`remdo-converge-change`](../../../docs/specs/skills/remdo-converge-change.md)
+[`remdo-converge-change`](../../../docs/specs/agents/skills/remdo-converge-change.md)
 contract. Do not expand intended behavior.
 
 ## Fix the scope
@@ -36,7 +36,7 @@ For every verifier result:
 
 1. Wait for verification to finish.
 2. Collect every failed check and
-   [`confirmed` finding](../../../docs/specs/skills/remdo-verify-change.md#findings)
+   [`confirmed` finding](../../../docs/specs/agents/skills/remdo-verify-change.md#findings)
    you can correct into one complete correction batch. Preserve the verifier's
    finding dispositions and record confirmed findings that cannot be corrected.
 3. If commit-range `HEAD` is detached, do not apply the correction batch;
@@ -54,7 +54,7 @@ For every verifier result:
 Do not amend, create an empty commit, or push.
 
 Determine convergence under the authoritative specification's
-[Convergence](../../../docs/specs/skills/remdo-converge-change.md#convergence)
+[Convergence](../../../docs/specs/agents/skills/remdo-converge-change.md#convergence)
 contract.
 
 ## Commit authority
@@ -69,10 +69,10 @@ Resolved uncommitted scope does not authorize commits.
 ## Report
 
 Return the result defined by the authoritative specification's
-[Result](../../../docs/specs/skills/remdo-converge-change.md#result) section.
+[Result](../../../docs/specs/agents/skills/remdo-converge-change.md#result) section.
 
 ## References
 
-- [Convergence contract](../../../docs/specs/skills/remdo-converge-change.md)
-- [Verification contract](../../../docs/specs/skills/remdo-verify-change.md)
+- [Convergence contract](../../../docs/specs/agents/skills/remdo-converge-change.md)
+- [Verification contract](../../../docs/specs/agents/skills/remdo-verify-change.md)
 - [Agent guidelines](../../../AGENTS.md)

--- a/.agents/skills/remdo-merge-main/SKILL.md
+++ b/.agents/skills/remdo-merge-main/SKILL.md
@@ -6,7 +6,7 @@ description: Merge the latest fetched origin/main into the current attached bran
 # RemDo Merge Main
 
 Implement the authoritative
-[`remdo-merge-main`](../../../docs/specs/skills/remdo-merge-main.md) contract.
+[`remdo-merge-main`](../../../docs/specs/agents/skills/remdo-merge-main.md) contract.
 Invocation declares the autonomous scope in [Authority](#authority).
 
 ## Start
@@ -83,4 +83,4 @@ authorize pull, rebase, push, force-push, or other remote mutation.
 ## Report
 
 Return the contract's
-[`Result`](../../../docs/specs/skills/remdo-merge-main.md#result).
+[`Result`](../../../docs/specs/agents/skills/remdo-merge-main.md#result).

--- a/.agents/skills/remdo-verify-change/SKILL.md
+++ b/.agents/skills/remdo-verify-change/SKILL.md
@@ -6,7 +6,7 @@ description: Verify a default or explicitly selected RemDo uncommitted or Git-ra
 # RemDo Verify Change
 
 Verify one scope under the authoritative
-[`remdo-verify-change`](../../../docs/specs/skills/remdo-verify-change.md)
+[`remdo-verify-change`](../../../docs/specs/agents/skills/remdo-verify-change.md)
 contract.
 Remain read-only: do not edit, stage, commit, or run checks intended to change
 the selected scope.
@@ -80,10 +80,10 @@ a fixed phrase list for this semantic judgment.
 
 After both review attempts finish, classify every finding under the
 authoritative specification's
-[Findings](../../../docs/specs/skills/remdo-verify-change.md#findings) contract.
+[Findings](../../../docs/specs/agents/skills/remdo-verify-change.md#findings) contract.
 Keep verification read-only.
 
 ## Report
 
 Return the result exactly as defined by the authoritative specification's
-[Result](../../../docs/specs/skills/remdo-verify-change.md#result) section.
+[Result](../../../docs/specs/agents/skills/remdo-verify-change.md#result) section.

--- a/.agents/skills/spec-complexity/SKILL.md
+++ b/.agents/skills/spec-complexity/SKILL.md
@@ -6,7 +6,7 @@ description: Assess a caller-named specification against its implementation, tes
 # Spec Complexity
 
 Assess one specification under the authoritative
-[`spec-complexity`](../../../docs/specs/skills/spec-complexity.md) contract.
+[`spec-complexity`](../../../docs/specs/agents/skills/spec-complexity.md) contract.
 Remain read-only.
 
 ## Assess the specification
@@ -36,4 +36,4 @@ requests them.
 ## Report
 
 Return the report defined by the specification's
-[Result](../../../docs/specs/skills/spec-complexity.md#result) section.
+[Result](../../../docs/specs/agents/skills/spec-complexity.md#result) section.

--- a/docs/specs/agents/skills/remdo-converge-change.md
+++ b/docs/specs/agents/skills/remdo-converge-change.md
@@ -2,7 +2,7 @@
 
 This skill verifies a repository change, applies every correction
 supported by the evidence, and repeats until no further correction can be
-determined. One [change scope](../agents/change-scope.md) bounds the run; the
+determined. One [change scope](../change-scope.md) bounds the run; the
 skill does not select or expand intended behavior.
 
 ## Convergence

--- a/docs/specs/agents/skills/remdo-merge-main.md
+++ b/docs/specs/agents/skills/remdo-merge-main.md
@@ -8,7 +8,7 @@ and recovery from an interrupted run are also outside the capability.
 ## Authority
 
 The skill declares the [autonomous
-scope](../../../AGENTS.md#safety--process) for the branch update, merge and
+scope](../../../../AGENTS.md#safety--process) for the branch update, merge and
 correction commits, and determined conflict resolutions. Preserve mode also
 covers saving and restoring local work.
 
@@ -47,7 +47,7 @@ the Git merge state for manual recovery.
 ## Verification
 
 An up-to-date or fast-forward result requires no repository check. A merge
-commit requires the [full repository check](../../../AGENTS.md#checks).
+commit requires the [full repository check](../../../../AGENTS.md#checks).
 
 When verification fails, the capability commits every determined correction
 caused by integrating the target, then runs complete verification again. An

--- a/docs/specs/agents/skills/remdo-verify-change.md
+++ b/docs/specs/agents/skills/remdo-verify-change.md
@@ -1,7 +1,7 @@
 # remdo-verify-change
 
 The skill verifies one [change
-scope](../agents/change-scope.md). It reports evidence and findings without
+scope](../change-scope.md). It reports evidence and findings without
 changing repository state, approving the scope, or controlling its lifecycle.
 
 The verifier resolves its optional input under the change-scope contract. It
@@ -27,20 +27,20 @@ until verification finishes.
 ```
 
 The verifier runs the [repository checks prescribed for the agent mode and
-scope](../../../AGENTS.md#checks) in place.
+scope](../../../../AGENTS.md#checks) in place.
 
 ## Reviews
 
 The verifier invokes the [read-only
-runner](../agents/tools/read-only-runner.md#call) independently for Codex and
+runner](../tools/read-only-runner.md#call) independently for Codex and
 Claude with a `review` invocation and the resolved change scope. Their
 identities remain distinct in the result.
 For Claude, the verifier exercises the caller judgement required by the runner's
-[trusted-prompt level](../agents/tools/read-only-runner.md#trusted-prompt): it
+[trusted-prompt level](../tools/read-only-runner.md#trusted-prompt): it
 judges the runner-constructed vendor-owned native review command and its
 resolved-scope arguments to satisfy that level.
 
-Review [results](../agents/tools/read-only-runner.md#result) are independent:
+Review [results](../tools/read-only-runner.md#result) are independent:
 one never interrupts another. The verifier reports `unavailable` and `failed`
 directly. It treats `responded` as `completed`, includes the complete report,
 and interprets its findings unless the report indicates that inspection of the
@@ -57,9 +57,9 @@ effects on content preservation, ownership, and links remain subject to review.
 Reviewer disagreement alone does not invalidate intended behavior established
 by the caller. When caller intent resolves an objection, the verifier still
 checks that the resulting behavior is represented as
-[target behavior](../../documentation.md#target-behavior) by its current
+[target behavior](../../../documentation.md#target-behavior) by its current
 contract owner, including a brief
-[rationale](../../documentation.md#minimality) only when its omission would
+[rationale](../../../documentation.md#minimality) only when its omission would
 reopen the decision. Implementation and test choices that establish no durable
 behavior require no documentation.
 

--- a/docs/specs/agents/skills/spec-complexity.md
+++ b/docs/specs/agents/skills/spec-complexity.md
@@ -12,7 +12,7 @@ The report answers:
 
 The skill assesses a specification named by the caller against its current
 implementation, tests, and Git history. The specification is the current
-[contract owner](../../documentation.md#ownership) for the behavior under
+[contract owner](../../../documentation.md#ownership) for the behavior under
 assessment.
 
 Each area caused by the specification identifies:

--- a/docs/specs/feedback-cases/README.md
+++ b/docs/specs/feedback-cases/README.md
@@ -5,6 +5,10 @@ specifications are written. This README defines how that evidence is structured
 and maintained. The evidence does not define accepted behavior or
 [documentation rules](../../documentation.md).
 
+The current contracts represented by this evidence are
+[`remdo-verify-change`](../agents/skills/remdo-verify-change.md) and the
+[read-only runner](../agents/tools/read-only-runner.md).
+
 A **feedback case** preserves evidence for later specification research and
 testing. `Post-change` is the version considered a better fit for the recorded
 change request. A case does not claim that version is canonical, generally

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -111,11 +111,6 @@ Remove rejected or obsolete items and empty sections.
   current authoritative documentation or public APIs for external dependencies
   before using [empirical checks](documentation.md#empirical-checks).
 
-- **Agent specification structure.** Move the
-  [`remdo-verify-change`](specs/skills/remdo-verify-change.md) specification
-  under `docs/specs/agents/skills/` and update all inbound links in the same
-  change.
-
 - **Development change workflow design.** Before implementing the initial
   [workflow contract](specs/agents/development-change-workflow.md), validate its
   phase boundaries through real changes and revise them when evidence requires.


### PR DESCRIPTION
…lls — update SKILL paths, cross-references, and README contract pointers