### PR TITLE
docs: align runtime config links — update AGENTS and agent instructio…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,9 +30,10 @@ owner. Provider-specific surfaces may load it alongside their own rules.
   - **Tracked code comments:**
     [Code comments](docs/dev/contributing.md#code-comments).
 - **Long-term product constraints:** [Project principles](docs/principles.md).
-- **Runtime configuration:** [Configuration](docs/config.md).
+- **Runtime configuration:**
+  [Configuration](docs/specs/runtime/configuration.md).
   - **Port and origin derivation:**
-    [Derivation rules](docs/config.md#derivation-rules).
+    [Derivation rules](docs/specs/runtime/configuration.md#derivation-rules).
 - **Verification runtime:** [Test Harness](docs/specs/testing/test-harness.md).
 - **Tracked repository follow-up:** [RemDo TODO](docs/todo.md#tracked-follow-up).
 - **Local runtime procedures:**

--- a/docs/specs/agents/instructions.md
+++ b/docs/specs/agents/instructions.md
@@ -68,9 +68,10 @@ documentation. Route agents by the question they need to answer:
   - **Tracked code comments:**
     [Code comments](../../dev/contributing.md#code-comments).
 - **Long-term product constraints:** [Project principles](../../principles.md).
-- **Runtime configuration:** [Configuration](../../config.md).
+- **Runtime configuration:**
+  [Configuration](../runtime/configuration.md).
   - **Port and origin derivation:**
-    [Derivation rules](../../config.md#derivation-rules).
+    [Derivation rules](../runtime/configuration.md#derivation-rules).
 - **Verification runtime:** [Test Harness](../testing/test-harness.md).
 - **Tracked repository follow-up:**
   [RemDo TODO](../../todo.md#tracked-follow-up).


### PR DESCRIPTION
…ns to specs runtime configuration paths