### PR TITLE
docs(documentation): clarify normative vs informative docs semantics …

### DIFF
--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -50,8 +50,6 @@ infer that a fixture value exists.
 
 ## References
 
-These sources directly inform the coverage policy; they do not override it.
-
 - [Software Engineering at Google: Unit Testing](https://abseil.io/resources/swe-book/html/ch12.html)
   — behavior through public APIs, independent outcomes, and resilience to
   behavior-preserving implementation changes.

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -49,13 +49,21 @@ Each durable statement lives with the owner of the question it answers.
 - **Internal owners.** A document links inline at first use of another owner's
   term or contract.
 - **Contract migration.** A migration moves the complete contract, updates
-  inbound links, and removes the former normative definition in the same change.
+  inbound links, and removes the definition from the former owner in the same change.
 
 ## Contracts
 
 Contracts are clear without consulting external sources.
 
-**Normative default.** Contract clauses are normative unless marked otherwise.
+**Authority and status.** A current owner is authoritative for the question it
+answers. Its accepted behavior, definitions, and rules are normative unless
+marked informative. Informative content may explain, justify, track, or
+preserve evidence, but cannot establish or change accepted behavior or rules.
+
+Examples, tables, and diagrams inherit the status of their surrounding content
+unless identified as informative. Status follows content's role, not
+capitalization, implementation status, or [verification](#verification)
+method.
 
 ### Target behavior
 
@@ -63,8 +71,9 @@ A durable specification states its target behavior as fact in timeless prose,
 regardless of implementation status.
 
 [Tracked follow-up](todo.md#tracked-follow-up) records future work and known
-gaps. Entries range from decided changes to unresolved questions and preserve
-only the context useful for returning to the work.
+gaps. Its entries are informative and may identify implementation that does not
+yet satisfy target behavior. Entries range from decided work to unresolved
+questions and preserve only the context useful for returning to the work.
 
 ### Minimality
 
@@ -82,8 +91,8 @@ only the context useful for returning to the work.
   mechanism. A detail belongs in the contract when choosing differently would
   break the promise; one that only determines how the promise is met belongs in
   the implementation. Named external interfaces, flags, and settings are mechanisms.
-- **Rationale.** Keep brief rationale only when removing it could reopen a
-  settled decision.
+- **Rationale.** Rationale is informative. Keep it only when removing it could
+  reopen a settled decision.
 - **Edge behavior.** Preserve materially relevant boundaries, failures, and no-ops.
 - **Sufficiency.** If two reasonable implementers could produce materially
   different behavior, clarify the contract or surface the unresolved product decision.
@@ -145,8 +154,7 @@ Use a diagram only when it makes an important relationship materially clearer
 than prose. Keep the smallest diagram sufficient to answer its question and
 split views when secondary relationships obscure the primary one. Include only
 relevant states and transitions, but retain critical ownership, safety, and
-rollback boundaries regardless of duration. A diagram has the normative status
-of its surrounding content unless marked illustrative.
+rollback boundaries regardless of duration.
 
 When a diagram is primary, it owns the actors, relationships, order, and loops
 it shows; do not restate them. Label steps with activities and transitions with
@@ -184,11 +192,13 @@ independently, otherwise at first use.
 
 #### Future
 
-Use for brief triggers describing long-horizon work related to the owned behavior.
+Future sections are informative. Use them for brief triggers describing
+long-horizon work related to the owned behavior.
 
 #### References
 
-Use for external sources and dependencies the document relies on.
+References are informative. Use them for external sources that informed the
+document and dependencies named by its contract.
 
 ## Specification structure
 
@@ -217,6 +227,10 @@ Use for external sources and dependencies the document relies on.
 - [Write the Docs: docs as code](https://www.writethedocs.org/guide/docs-as-code/) — docs reviewed and tested like code.
 - [NASA Systems Engineering Handbook](https://www.nasa.gov/wp-content/uploads/2018/09/nasa_systems_engineering_handbook_0.pdf) — verification methods recorded with their requirements.
 - [Google style: timeless documentation](https://developers.google.com/style/timeless-documentation) — timeless prose.
+- [RFC 8174](https://www.rfc-editor.org/rfc/rfc8174.html) — normative prose and
+  requirement-keyword capitalization.
+- [W3C Manual of Style](https://www.w3.org/guide/manual-of-style/#normative-material)
+  — normative and informative status.
 - [arc42](https://arc42.org/overview) — decision rationale as load-bearing.
 - [Microsoft style: headings](https://learn.microsoft.com/en-us/style-guide/scannable-content/headings) — heading granularity and run-in headings.
 - [GitHub Copilot: effective review instructions](https://docs.github.com/en/copilot/tutorials/customize-code-review)

--- a/docs/legacy-backlog.md
+++ b/docs/legacy-backlog.md
@@ -2,12 +2,12 @@
 
 This file retains unresolved work recorded before
 [`docs/todo.md`](todo.md) became RemDo's authoritative TODO and sole intake. It
-is closed to new entries; record new temporary work in `docs/todo.md`. This file
-does not define or override accepted target behavior.
+is closed to new entries; record new temporary work in `docs/todo.md`.
 
-Existing entries remain tracked until they are completed and deleted or moved
-to `docs/todo.md` or an owning spec's `Future` section. They remain part of
-duplicate and review-suppression checks while they are here.
+Existing entries are [informative](documentation.md#contracts) and remain
+tracked until they are completed and deleted or moved to `docs/todo.md` or an
+owning spec's `Future` section. They remain part of duplicate and
+review-suppression checks while they are here.
 
 Rules:
 
@@ -272,8 +272,8 @@ Tracks the gaps between [Home](specs/outliner/home.md) and the [view header](spe
   encoding a second ad-hoc route now.
 
 The [view header](specs/outliner/view-header.md) (Model F) is specified but not
-yet built; the entries below track the gap. Suspends the view-header rules in
-`specs/outliner/view-header.md` and the pure-nav breadcrumb claim in [Zoom breadcrumbs](specs/outliner/zoom.md#breadcrumbs).
+yet built; the entries below track implementation gaps against its rules and
+the pure-nav breadcrumb behavior in [Zoom breadcrumbs](specs/outliner/zoom.md#breadcrumbs).
 
 - No view header is rendered: while zoomed the zoom root remains the editable
   top outline `ListItemNode`, and at the document root the document name remains

--- a/docs/specs/agents/instructions.md
+++ b/docs/specs/agents/instructions.md
@@ -134,8 +134,6 @@ narrower owners can take over.
 
 ## References
 
-These sources inform instruction design; they do not override this contract.
-
 - [OpenAI Codex: Custom instructions with AGENTS.md](https://learn.chatgpt.com/docs/agent-configuration/agents-md)
   — instruction discovery, precedence, and project-document budget.
 - [OpenAI: Harness engineering](https://openai.com/index/harness-engineering/)

--- a/docs/specs/feedback-cases/README.md
+++ b/docs/specs/feedback-cases/README.md
@@ -1,9 +1,8 @@
 # Specification Feedback Cases
 
-This directory records non-normative feedback cases about how RemDo
-specifications are written. This README defines how that evidence is structured
-and maintained. The evidence does not define accepted behavior or
-[documentation rules](../../documentation.md).
+This directory records [informative](../../documentation.md#contracts) feedback
+cases about how RemDo specifications are written. This README owns their
+evidence structure and maintenance rules.
 
 The current contracts represented by this evidence are
 [`remdo-deps-refresh`](../agents/skills/remdo-deps-refresh.md),

--- a/docs/specs/outliner/home.md
+++ b/docs/specs/outliner/home.md
@@ -20,8 +20,9 @@ is a [note](./note-model.md), and Home is the surface from which its documents a
 3. Each listed document shows its display name and opens that document when
    activated, landing on its [document-root view](./zoom.md#visibility-and-editing-boundary).
 4. Home presents three additional entry-point groups alongside the document
-   list: **Favorites**, **Tags**, and **Recents**. Each is a list of document
-   shortcuts, shown as static placeholder entries until the [backing sources exist](#future).
+   list: **Favorites**, **Tags**, and **Recents**. Favorites lists entries from
+   favoriting, Tags from tagging, and Recents from visit history. An entry may
+   target a document or a note within one.
 5. A group with no entries is omitted from Home entirely; Home never shows an
    empty group as a placeholder.
 
@@ -37,9 +38,10 @@ is a [note](./note-model.md), and Home is the surface from which its documents a
 
 ## Future
 
-- **Entry-point groups need their own sources.** Replace the static placeholder
-  Favorites, Tags, and Recents with real entries once favoriting, tagging, and
-  visit-history exist — entries that may target a document or a note within one.
+- **Entry-point backing sources.** Implement favoriting, tagging, and
+  visit-history sources for the corresponding groups, replacing the current
+  Favorites and Recents document-list slices and empty Tags source, and support
+  document- and note-target entries.
 - **Home content in the sidebar.** Also surface Home's document, Favorites,
   Tags, and Recents groups in a persistent navigation sidebar; its division of
   responsibility with Home remains open.

--- a/src/client/app/routes/document/home-content.ts
+++ b/src/client/app/routes/document/home-content.ts
@@ -20,11 +20,11 @@ export interface HomeContent {
 
 // Builds Home's content from the live document sources. Favorites and Recents
 // are static placeholder slices of the real document list; Tags is left empty to
-// exercise the hide-when-empty rule. Replaced by real favoriting/tagging/
-// visit-history sources later (see home.md#future). A document listed here also
-// appears under its source group — an entry-point group is a shortcut into the
-// same documents, so overlap (and a shared data-home-document-ref) is expected,
-// as it will be with real favorites/recents.
+// exercise the hide-when-empty rule. Their replacement is tracked in
+// docs/specs/outliner/home.md#future. A document listed here also appears under
+// its source group — an entry-point group is a shortcut into the same documents,
+// so overlap (and a shared data-home-document-ref) is expected, as it will be
+// with real favorites/recents.
 export function buildHomeContent(documentSources: readonly DocumentSourceNote[]): HomeContent {
   const sources: HomeDocumentSource[] = documentSources.map((documentSource) => ({
     id: documentSource.id(),


### PR DESCRIPTION
…— refine accepted behavior ownership, backlog tracking, and home entry-point source wording