### PR TITLE
docs(agents): align repository authority text with root AGENTS — cent…

### DIFF
--- a/.agents/skills/remdo-merge-main/SKILL.md
+++ b/.agents/skills/remdo-merge-main/SKILL.md
@@ -6,7 +6,6 @@ description: Merge the latest fetched origin/main into the current attached bran
 # RemDo Merge Main
 
 Implement the authoritative [`remdo-merge-main`](../../../docs/specs/agents/skills/remdo-merge-main.md) contract.
-Invocation declares the autonomous scope in [Authority](#authority).
 
 ## Start
 
@@ -70,13 +69,6 @@ Only after all saved paths and their index intent are accounted for, run
 If restoration remains uncertain, leave both the conflict and stash unchanged
 and report `restore-conflicted` for manual recovery. Otherwise report the
 retained integration outcome and, when verification ran, its outcome.
-
-## Authority
-
-Invocation declares an autonomous scope on the current branch for the runner's
-branch update, the merge and determined correction commits, determined conflict
-resolutions, and explicitly requested preservation and restoration. It does not
-authorize pull, rebase, push, force-push, or other remote mutation.
 
 ## Report
 

--- a/.agents/skills/remdo-simplify/SKILL.md
+++ b/.agents/skills/remdo-simplify/SKILL.md
@@ -9,7 +9,7 @@ Assess one
 [assessment target](../../../docs/specs/agents/assessment-target.md) under the
 authoritative
 [`remdo-simplify`](../../../docs/specs/agents/skills/remdo-simplify.md)
-contract. Remain read-only.
+contract.
 
 ## Resolve the target
 

--- a/.agents/skills/remdo-verify-change/SKILL.md
+++ b/.agents/skills/remdo-verify-change/SKILL.md
@@ -6,8 +6,6 @@ description: Verify a default or explicitly selected RemDo uncommitted or Git-ra
 # RemDo Verify Change
 
 Verify one scope under the authoritative [`remdo-verify-change`](../../../docs/specs/agents/skills/remdo-verify-change.md) contract.
-Remain read-only: do not edit, stage, commit, or run checks intended to change
-the selected scope.
 
 ## Resolve the scope
 
@@ -72,7 +70,7 @@ a fixed phrase list for this semantic judgment.
 ## Validate findings
 
 After both review attempts finish, classify every finding under the
-authoritative specification's [Findings](../../../docs/specs/agents/skills/remdo-verify-change.md#findings) contract. Keep verification read-only.
+authoritative specification's [Findings](../../../docs/specs/agents/skills/remdo-verify-change.md#findings) contract.
 
 ## Report
 

--- a/.agents/skills/spec-complexity/SKILL.md
+++ b/.agents/skills/spec-complexity/SKILL.md
@@ -8,7 +8,7 @@ description: Assess a selected RemDo change or repository subject against applic
 Assess one [assessment target](../../../docs/specs/agents/assessment-target.md) under
 the authoritative
 [`spec-complexity`](../../../docs/specs/agents/skills/spec-complexity.md)
-contract. Remain read-only.
+contract.
 
 ## Resolve the target
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,15 +42,17 @@ change. Do not add update-tracking sections to durable documents.
 
 - Inspect and edit within the requested scope without separate permission.
 - Commit only when the user explicitly authorizes it or an invoked skill grants
-  an autonomous commit scope. That authority includes staging only the
-  authorized commit. Other staging or unstaging, stashing, resets, and index
-  rewrites require an explicit user request. A plain change request grants
-  neither commit nor push authority.
+  it in its specification; that authority includes staging only the authorized
+  commit. A plain change request grants neither commit nor push authority.
+- A skill specification may grant autonomous repository authority only by
+  declaring its permitted effects, scope, and lifecycle.
+  Undeclared staging or unstaging, branch or ref changes, stashing, resets, and
+  index rewrites require an explicit user request.
 - Staged versus unstaged state does not signal completion, approval, protection,
   or task scope; edit files required by the task regardless of that state.
-- Ordinary `git fetch` is allowed. Pulling, opening a pull request, and fetches
-  with caller-supplied mutating refspecs require explicit user authority.
-  Pushing always requires a separate explicit user request.
+- Ordinary `git fetch` is allowed. Pulling, rebasing, opening a pull request,
+  and fetches with caller-supplied mutating refspecs require explicit user
+  authority. Pushing always requires a separate explicit user request.
 - Uncommitted work may be mid-transformation. A commit is coherent or tracks its
   precise remaining gap in [RemDo TODO](docs/todo.md#tracked-follow-up); when
   commit authority applies, record that gap without seeking separate approval.

--- a/docs/specs/agents/instructions.md
+++ b/docs/specs/agents/instructions.md
@@ -85,20 +85,9 @@ narrower owners can take over.
 
 #### Repository authority
 
-- Agents may inspect and edit within the requested scope. Committing requires
-  explicit user authority or an applicable skill-declared autonomous scope;
-  that authority includes staging only the authorized commit. Other staging or
-  unstaging, stashing, resets, and index rewrites require an explicit user
-  request. A plain change request grants neither commit nor push authority.
-- Staged versus unstaged state does not signal completion, approval, protection,
-  or task scope; agents edit files required by the task regardless of that state.
-- Ordinary `git fetch` is allowed. Pulling, opening a pull request, and fetches
-  with caller-supplied mutating refspecs require explicit user authority.
-  Pushing always requires a separate explicit user request.
-- Uncommitted work may be mid-transformation. A commit is coherent or tracks its
-  precise remaining gap in [RemDo TODO](../../todo.md#tracked-follow-up). When
-  commit authority applies, the agent records that gap without seeking separate
-  approval.
+The shared entry point owns [repository authority](../../../AGENTS.md#repository-authority),
+including default edit authority, skill-declared mutations, and operations that
+require explicit user authority.
 
 #### Isolation
 

--- a/docs/specs/agents/skills/remdo-converge-change.md
+++ b/docs/specs/agents/skills/remdo-converge-change.md
@@ -8,9 +8,9 @@ expand intended behavior.
 
 ## Authority
 
-[Repository authority](../instructions.md#repository-authority): corrections
-remain uncommitted for `uncommitted`; for a commit range on an attached branch,
-the skill autonomously commits each coherent correction batch.
+[Repository authority](../../../../AGENTS.md#repository-authority): the skill edits
+`uncommitted` corrections without staging them. For a commit range on an
+attached branch, it stages and commits each coherent correction batch.
 
 ## Convergence
 

--- a/docs/specs/agents/skills/remdo-deps-refresh.md
+++ b/docs/specs/agents/skills/remdo-deps-refresh.md
@@ -20,7 +20,7 @@ authority:
 ```
 
 `topic` means a [topic branch](../../../../CONTRIBUTING.md#git-workflow);
-`allowed` grants [repository authority](../instructions.md#repository-authority)
+`allowed` grants [repository authority](../../../../AGENTS.md#repository-authority)
 to commit. An absent or incompatible call yields `failed`.
 
 ## Run

--- a/docs/specs/agents/skills/remdo-merge-main.md
+++ b/docs/specs/agents/skills/remdo-merge-main.md
@@ -8,9 +8,11 @@ interrupted run are also outside the capability.
 
 ## Authority
 
-The skill declares the [autonomous scope](../instructions.md#repository-authority) for the branch update, merge and
-correction commits, and determined conflict resolutions. Preserve mode also
-covers saving and restoring local work.
+[Repository authority](../../../../AGENTS.md#repository-authority): invocation
+authorizes fast-forwarding or merging the target into the current branch,
+staging determined conflict resolutions, and committing determined
+corrections. Preserve mode also authorizes stashing and restoring requested
+local work.
 
 ## Target
 

--- a/docs/specs/agents/skills/remdo-merge-main.md
+++ b/docs/specs/agents/skills/remdo-merge-main.md
@@ -9,10 +9,10 @@ interrupted run are also outside the capability.
 ## Authority
 
 [Repository authority](../../../../AGENTS.md#repository-authority): invocation
-authorizes fast-forwarding or merging the target into the current branch,
-staging determined conflict resolutions, and committing determined
-corrections. Preserve mode also authorizes stashing and restoring requested
-local work.
+authorizes updating the local `origin/main` tracking ref to the fetched
+target, fast-forwarding or merging that target into the current branch, staging
+determined conflict resolutions, and committing determined corrections.
+Preserve mode also authorizes stashing and restoring requested local work.
 
 ## Target
 

--- a/docs/specs/agents/skills/remdo-prepare-change.md
+++ b/docs/specs/agents/skills/remdo-prepare-change.md
@@ -6,9 +6,10 @@ participating capabilities retain their contracts.
 
 ## Authority
 
-[Repository authority](../instructions.md#repository-authority): autonomous for
-owning-branch preparation after quick dialogue and for approved change work,
-including participant-defined commit units.
+[Repository authority](../../../../AGENTS.md#repository-authority): after quick
+dialogue, the skill may create or switch to the owning branch and transfer only
+work adopted by the change. After approval, it may edit and commit approved
+change work, including participant-defined commit units.
 
 ## Lifecycle
 
@@ -63,7 +64,7 @@ Legend:
   observable completion through focused developer decisions.
 - **Exploration.** Begins at the developer's request or accepted recommendation
   to investigate material uncertainty. Its transition establishes the question,
-  scope, any required [repository authority](../instructions.md#repository-authority), expected result,
+  scope, any required [repository authority](../../../../AGENTS.md#repository-authority), expected result,
   and return point. Repository changes remain disposable unless adopted.
 - **Owning branch ready.** Before retaining work, fetch `origin/main` and ensure
   the current [topic branch](../../../../CONTRIBUTING.md#git-workflow) uses its

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -45,10 +45,6 @@ short topic headings. Remove rejected or obsolete items and empty sections.
   decisions, and later evidence establish or reopen decisions, then align the
   specification and skill.
 
-- **Agent repository-authority declarations.** Define compact authority modes
-  in [Agent instructions](specs/agents/instructions.md#repository-authority) and
-  replace repeated per-skill permission prose with linked declarations.
-
 - **Condition ownership beyond capability calls.** Evaluate whether the
   [capability protocol](specs/agents/protocol.md) should generalize to other
   component boundaries. Define how independently invocable and

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -34,7 +34,10 @@ short topic headings. Remove rejected or obsolete items and empty sections.
   scripts and state machines that encode adaptive work without enough robustness
   to justify their maintenance. Prefer concise intent plus deterministic checks
   of stable repository invariants, then align each affected specification,
-  procedure, implementation, and coverage.
+  procedure, implementation, and coverage. For `remdo-merge-main`, simplify
+  target acquisition by fetching remote `main` directly into local
+  `origin/main`, pinning its OID, and leaving that fetch effect in place if a
+  later check refuses the merge.
 
 - **Prepare-change lifecycle.** Reconsider its dialogue, specification,
   approval, and execution flow as a whole so it is simple, flexible, and clear.


### PR DESCRIPTION
…ralize skill ownership links and remove duplicated repo rules