### PR TITLE
feat(prod): support loopback-only localhost HTTP origins in launcher …

### DIFF
--- a/docker/entrypoint-env.sh
+++ b/docker/entrypoint-env.sh
@@ -27,21 +27,33 @@ remdo_configure_internal_services() {
 remdo_configure_caddy_env() {
   : "${APP_ORIGIN:?Set APP_ORIGIN to the canonical public RemDo origin}"
   app_origin_protocol="$(remdo_origin_field "${APP_ORIGIN}" protocol)" || return 1
+  app_origin_hostname="$(remdo_origin_field "${APP_ORIGIN}" hostname)" || return 1
 
   if [ "${REMDO_DEV_CONTAINER:-false}" = "true" ]; then
     : "${REMDO_GATEWAY_BIND_ADDRESS:?Set REMDO_GATEWAY_BIND_ADDRESS for the development container}"
     CADDY_SITE_ADDRESS="${APP_ORIGIN}"
   else
-    if [ "${app_origin_protocol}" != "https:" ]; then
-      echo "APP_ORIGIN must use HTTPS outside the development container." >&2
-      return 1
-    fi
     unset REMDO_GATEWAY_BIND_ADDRESS
-    if [ -n "${PORT:-}" ]; then
-      CADDY_SITE_ADDRESS="http://$(remdo_origin_field "${APP_ORIGIN}" hostname):${PORT}"
-    else
-      CADDY_SITE_ADDRESS="${APP_ORIGIN}"
-    fi
+    case "${app_origin_protocol}:${app_origin_hostname}" in
+      http::*.localhost)
+        if [ "${REMDO_LAUNCHER_LOOPBACK_HTTP:-false}" != "true" ]; then
+          echo "HTTP *.localhost requires the self-hosted loopback launcher." >&2
+          return 1
+        fi
+        CADDY_SITE_ADDRESS="${APP_ORIGIN}"
+        ;;
+      https::*)
+        if [ -n "${PORT:-}" ]; then
+          CADDY_SITE_ADDRESS="http://${app_origin_hostname}:${PORT}"
+        else
+          CADDY_SITE_ADDRESS="${APP_ORIGIN}"
+        fi
+        ;;
+      *)
+        echo "APP_ORIGIN must use HTTPS unless it is a loopback-only *.localhost deployment." >&2
+        return 1
+        ;;
+    esac
   fi
 
   export APP_ORIGIN CADDY_SITE_ADDRESS

--- a/docs/guides/production-deployment.md
+++ b/docs/guides/production-deployment.md
@@ -29,6 +29,18 @@ daemons are supported.
    For direct host exposure, set `APP_ORIGIN` to its exact public HTTPS origin
    and set `HOST=0.0.0.0`.
 
+   For access through an SSH loopback tunnel without installing Caddy's local
+   CA, set `APP_ORIGIN` to a dedicated origin such as
+   `http://remdo-8443.localhost:8443` and keep `HOST=127.0.0.1`. This mode
+   requires Docker Engine 28 or newer. Bind both ends of the SSH forward to
+   `127.0.0.1`; SSH encrypts the connection between the browser and Docker
+   hosts while HTTP remains confined to their loopback interfaces.
+
+   ```sh
+   ssh -N -o ExitOnForwardFailure=yes \
+     -L 127.0.0.1:8443:127.0.0.1:8443 user@docker-host
+   ```
+
 3. For direct exposure, point the origin hostname's DNS A record at the host
    and allow inbound port 443. Rootless Docker requires the host to permit its
    daemon to publish that privileged port. The loopback example instead uses
@@ -42,10 +54,11 @@ daemons are supported.
    Rerunning the launcher builds successfully before gracefully replacing the
    container serving the same origin port.
 
-5. Open the printed `Docker target`. Caddy uses its internal CA for `.localhost`
-   and manages a publicly trusted certificate for a public DNS name. For the
-   loopback deployment, trust the Caddy root certificate beneath the persistent
-   data root on each browser client. At the default location, it is
+5. Open the printed `Docker target`. For HTTPS, Caddy uses its internal CA for
+   `.localhost` and manages a publicly trusted certificate for a public DNS
+   name. For an HTTPS loopback deployment, trust the Caddy root certificate
+   beneath the persistent data root on each browser client. At the default
+   location, it is
    `data/production/caddy/pki/authorities/local/root.crt`.
 6. The launcher returns after starting RemDo. Docker keeps the container
    running and restarts the complete instance after an unexpected failure. Use

--- a/docs/guides/production-deployment.md
+++ b/docs/guides/production-deployment.md
@@ -32,9 +32,9 @@ daemons are supported.
    For access through an SSH loopback tunnel without installing Caddy's local
    CA, set `APP_ORIGIN` to a dedicated origin such as
    `http://remdo-8443.localhost:8443` and keep `HOST=127.0.0.1`. This mode
-   requires Docker Engine 28 or newer. Bind both ends of the SSH forward to
-   `127.0.0.1`; SSH encrypts the connection between the browser and Docker
-   hosts while HTTP remains confined to their loopback interfaces.
+   requires a rootless Docker Engine 28 or newer. Bind both ends of the SSH
+   forward to `127.0.0.1`; SSH encrypts the connection between the browser and
+   Docker hosts while HTTP remains confined to their loopback interfaces.
 
    ```sh
    ssh -N -o ExitOnForwardFailure=yes \

--- a/docs/specs/runtime/configuration.md
+++ b/docs/specs/runtime/configuration.md
@@ -19,11 +19,14 @@ Server-only requirements do not apply to browser configuration or production uti
   loopback-only access; direct self-hosted exposure and externally hosted
   production require an explicit exact HTTPS origin. The self-hosted launcher
   also accepts an exact `http://*.localhost:<port>` origin only with
-  `HOST=127.0.0.1` and Docker Engine 28 or newer. Older Docker releases can
-  expose localhost-published ports to hosts on the same L2 network. The
-  application server also accepts the development container's derived HTTP
-  origin. For self-hosted Docker, its effective port selects the host-side
-  published [gateway](../../architecture.md#gateway) port; ports reserved for
+  `HOST=127.0.0.1` and a rootless Docker Engine 28 or newer. Rootless Docker
+  keeps container addresses inside its network namespace; rootful Docker can
+  permit direct routing to the container port despite a loopback-only host
+  publication. Older Docker releases can expose localhost-published ports to
+  hosts on the same L2 network. The application server also accepts the
+  development container's derived HTTP origin. For self-hosted Docker, its
+  effective port selects the host-side published
+  [gateway](../../architecture.md#gateway) port; ports reserved for
   container-internal services are rejected.
   [Routing and origin](../../architecture.md#routing-and-origin-boundary) owns its collaboration use;
   [access control](../access/access-control.md#csrf-protection) owns its authentication use.

--- a/docs/specs/runtime/configuration.md
+++ b/docs/specs/runtime/configuration.md
@@ -19,13 +19,10 @@ Server-only requirements do not apply to browser configuration or production uti
   loopback-only access; direct self-hosted exposure and externally hosted
   production require an explicit exact HTTPS origin. The self-hosted launcher
   also accepts an exact `http://*.localhost:<port>` origin only with
-  `HOST=127.0.0.1` and a rootless Docker Engine 28 or newer. Rootless Docker
-  keeps container addresses inside its network namespace; rootful Docker can
-  permit direct routing to the container port despite a loopback-only host
-  publication. Older Docker releases can expose localhost-published ports to
-  hosts on the same L2 network. The application server also accepts the
-  development container's derived HTTP origin. For self-hosted Docker, its
-  effective port selects the host-side published
+  `HOST=127.0.0.1` and a rootless Docker Engine 28 or newer, keeping HTTP
+  confined to loopback. The application server also accepts the development
+  container's derived HTTP origin. For self-hosted Docker, its effective port
+  selects the host-side published
   [gateway](../../architecture.md#gateway) port; ports reserved for
   container-internal services are rejected.
   [Routing and origin](../../architecture.md#routing-and-origin-boundary) owns its collaboration use;

--- a/docs/specs/runtime/configuration.md
+++ b/docs/specs/runtime/configuration.md
@@ -17,10 +17,13 @@ Server-only requirements do not apply to browser configuration or production uti
   Development derives it as `http://<PUBLIC_HOST>:<PORT>`. The self-hosted
   production launcher defaults it to `https://remdo.localhost:8443` for
   loopback-only access; direct self-hosted exposure and externally hosted
-  production require an explicit exact HTTPS origin. The application server
-  also accepts the development container's derived HTTP origin. For self-hosted
-  Docker, its effective port selects the host-side published
-  [gateway](../../architecture.md#gateway) port; ports reserved for
+  production require an explicit exact HTTPS origin. The self-hosted launcher
+  also accepts an exact `http://*.localhost:<port>` origin only with
+  `HOST=127.0.0.1` and Docker Engine 28 or newer. Older Docker releases can
+  expose localhost-published ports to hosts on the same L2 network. The
+  application server also accepts the development container's derived HTTP
+  origin. For self-hosted Docker, its effective port selects the host-side
+  published [gateway](../../architecture.md#gateway) port; ports reserved for
   container-internal services are rejected.
   [Routing and origin](../../architecture.md#routing-and-origin-boundary) owns its collaboration use;
   [access control](../access/access-control.md#csrf-protection) owns its authentication use.

--- a/tests/unit/docker-entrypoint-env.spec.ts
+++ b/tests/unit/docker-entrypoint-env.spec.ts
@@ -81,13 +81,34 @@ describe('docker entrypoint Caddy environment', () => {
     });
   });
 
-  it('rejects HTTP outside the development container', () => {
+  it('serves an explicit localhost production origin without TLS', () => {
+    expect(readCaddyEnv({
+      APP_ORIGIN: 'http://remdo-8443.localhost:8443',
+      REMDO_LAUNCHER_LOOPBACK_HTTP: 'true',
+    })).toEqual({
+      bindAddress: '',
+      siteAddress: 'http://remdo-8443.localhost:8443',
+    });
+  });
+
+  it('rejects localhost HTTP when the production launcher did not select it', () => {
     const result = runEntryPointEnv('remdo_configure_caddy_env', {
-      APP_ORIGIN: 'http://localhost:8080',
+      APP_ORIGIN: 'http://remdo-8443.localhost:8443',
     });
 
     expect(result.status).not.toBe(0);
-    expect(result.stderr).toContain('APP_ORIGIN must use HTTPS');
+    expect(result.stderr).toContain('requires the self-hosted loopback launcher');
+  });
+
+  it('rejects HTTP outside a dedicated localhost subdomain', () => {
+    for (const appOrigin of ['http://localhost:8080', 'http://remdo.example.test:8080']) {
+      const result = runEntryPointEnv('remdo_configure_caddy_env', {
+        APP_ORIGIN: appOrigin,
+      });
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain('APP_ORIGIN must use HTTPS unless');
+    }
   });
 
   it('rejects an invalid development-container origin', () => {

--- a/tests/unit/prod-docker-launcher.spec.ts
+++ b/tests/unit/prod-docker-launcher.spec.ts
@@ -23,6 +23,9 @@ case "$1" in
   version)
     printf '%s\n' "\${REMDO_FAKE_DOCKER_VERSION:-29.5.0}"
     ;;
+  info)
+    printf '%s\n' "\${REMDO_FAKE_DOCKER_SECURITY_OPTIONS:-[\\"name=rootless\\"]}"
+    ;;
   container)
     [ "$2" = inspect ]
     [ "\${REMDO_FAKE_CONTAINER_EXISTS:-false}" = true ]
@@ -106,6 +109,7 @@ describe('prod Docker launcher', () => {
         PORT_BASE: '9000',
         REMDO_DOCKER_NETWORK: 'host',
         REMDO_FAKE_DOCKER_LOG: dockerLog,
+        REMDO_FAKE_DOCKER_SECURITY_OPTIONS: '["name=rootless"]',
         REMDO_FAKE_DOCKER_STOPPED: dockerStopped,
         REMDO_FAKE_MKDIR_LOG: mkdirLog,
         REMDO_FAKE_SLEEP_LOG: sleepLog,
@@ -224,7 +228,10 @@ describe('prod Docker launcher', () => {
     });
 
     expect(result.status, result.stderr).toBe(0);
-    expect(dockerCalls[0]).toEqual(['version', '--format', '{{.Server.Version}}']);
+    expect(dockerCalls.slice(0, 2)).toEqual([
+      ['info', '--format', '{{json .SecurityOptions}}'],
+      ['version', '--format', '{{.Server.Version}}'],
+    ]);
     const runArgs = findDockerCall(dockerCalls, 'run');
     expect(dockerOptionValues(runArgs, '-p')).toEqual(['127.0.0.1:8443:8443']);
     expect(dockerEnvironment(runArgs)).toMatchObject({
@@ -257,7 +264,21 @@ describe('prod Docker launcher', () => {
 
     expect(result.status).not.toBe(0);
     expect(result.stderr).toContain('Loopback HTTP requires Docker Engine 28.0 or newer');
-    expect(dockerCalls).toEqual([['version', '--format', '{{.Server.Version}}']]);
+    expect(dockerCalls).toEqual([
+      ['info', '--format', '{{json .SecurityOptions}}'],
+      ['version', '--format', '{{.Server.Version}}'],
+    ]);
+  });
+
+  it('rejects loopback HTTP on a rootful Docker daemon', () => {
+    const { result, dockerCalls } = runLauncher({
+      APP_ORIGIN: 'http://remdo-8443.localhost:8443',
+      REMDO_FAKE_DOCKER_SECURITY_OPTIONS: '["name=seccomp"]',
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('Loopback HTTP requires a rootless Docker daemon.');
+    expect(dockerCalls).toEqual([['info', '--format', '{{json .SecurityOptions}}']]);
   });
 
   it('stops a container that fails initial health before reporting success', () => {

--- a/tests/unit/prod-docker-launcher.spec.ts
+++ b/tests/unit/prod-docker-launcher.spec.ts
@@ -20,6 +20,9 @@ case "$1" in
   build)
     exit "\${REMDO_FAKE_DOCKER_BUILD_STATUS:-0}"
     ;;
+  version)
+    printf '%s\n' "\${REMDO_FAKE_DOCKER_VERSION:-29.5.0}"
+    ;;
   container)
     [ "$2" = inspect ]
     [ "\${REMDO_FAKE_CONTAINER_EXISTS:-false}" = true ]
@@ -215,16 +218,46 @@ describe('prod Docker launcher', () => {
     expect(dockerOptionValues(runArgs, '-p')).toEqual(['0.0.0.0:443:443']);
   });
 
-  it('defers exact origin validation to the container while deriving its explicit port', () => {
+  it('publishes an explicit HTTP localhost origin only on loopback', () => {
     const { result, dockerCalls } = runLauncher({
-      APP_ORIGIN: 'http://remdo.example.com:9443',
+      APP_ORIGIN: 'http://remdo-8443.localhost:8443',
     });
 
     expect(result.status, result.stderr).toBe(0);
+    expect(dockerCalls[0]).toEqual(['version', '--format', '{{.Server.Version}}']);
     const runArgs = findDockerCall(dockerCalls, 'run');
-    expect(dockerOptionValues(runArgs, '--name')).toEqual(['remdo-9443']);
-    expect(dockerOptionValues(runArgs, '-p')).toEqual(['127.0.0.1:9443:9443']);
-    expect(dockerEnvironment(runArgs).APP_ORIGIN).toBe('http://remdo.example.com:9443');
+    expect(dockerOptionValues(runArgs, '-p')).toEqual(['127.0.0.1:8443:8443']);
+    expect(dockerEnvironment(runArgs)).toMatchObject({
+      APP_ORIGIN: 'http://remdo-8443.localhost:8443',
+      REMDO_LAUNCHER_LOOPBACK_HTTP: 'true',
+    });
+  });
+
+  it('rejects HTTP when it is not an explicit loopback-only localhost origin', () => {
+    const unsafeOrigins: Record<string, string>[] = [
+      { APP_ORIGIN: 'http://remdo.example.com:8443' },
+      { APP_ORIGIN: 'http://localhost:8443' },
+      { APP_ORIGIN: 'http://remdo.localhost:8443/path' },
+      { APP_ORIGIN: 'http://remdo.localhost:8443', HOST: '0.0.0.0' },
+    ];
+    for (const overrides of unsafeOrigins) {
+      const { result, dockerCalls } = runLauncher(overrides);
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toMatch(/HTTP APP_ORIGIN|requires HOST=127\.0\.0\.1/);
+      expect(dockerCalls).toEqual([]);
+    }
+  });
+
+  it('rejects loopback HTTP on Docker engines with unsafe localhost publishing', () => {
+    const { result, dockerCalls } = runLauncher({
+      APP_ORIGIN: 'http://remdo-8443.localhost:8443',
+      REMDO_FAKE_DOCKER_VERSION: '27.5.1',
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('Loopback HTTP requires Docker Engine 28.0 or newer');
+    expect(dockerCalls).toEqual([['version', '--format', '{{.Server.Version}}']]);
   });
 
   it('stops a container that fails initial health before reporting success', () => {

--- a/tools/docker-test.sh
+++ b/tools/docker-test.sh
@@ -57,11 +57,15 @@ BOOTSTRAP_DATA_DIR="${TEST_DATA_DIR%/}/bootstrap-home"
 # It uses the next reserved Docker E2E port and a separate container/data dir.
 PROD_BRIDGE_PORT="$((PORT_BASE + 9))"
 remdo_assert_browser_safe_port "${PROD_BRIDGE_PORT}"
+PROD_BRIDGE_BROWSER_HOST="remdo-${PROD_BRIDGE_PORT}.localhost"
 PROD_BRIDGE_CONTAINER_NAME="remdo-${PROD_BRIDGE_PORT}"
-PROD_BRIDGE_APP_ORIGIN="https://${DOCKER_TEST_BROWSER_HOST}:${PROD_BRIDGE_PORT}"
+PROD_BRIDGE_APP_ORIGIN="http://${PROD_BRIDGE_BROWSER_HOST}:${PROD_BRIDGE_PORT}"
 PROD_BRIDGE_HEALTH_URL="${PROD_BRIDGE_APP_ORIGIN%/}/health"
 PROD_BRIDGE_DATA_DIR="${TEST_DATA_DIR%/}/prod-bridge-home"
+PROD_BRIDGE_SOURCE_DATA_DIR="${TEST_DATA_DIR%/}/prod-bridge-source"
 PROD_BRIDGE_LAUNCH_LOG="${TEST_DATA_DIR%/}/prod-bridge-launcher.log"
+PROD_BRIDGE_AUTH_STATE_PATH="${TEST_DATA_DIR%/}/prod-bridge-auth-state.json"
+PROD_BRIDGE_DOCUMENT_ID_PATH="${TEST_DATA_DIR%/}/prod-bridge-document-id.txt"
 
 # Fourth scenario: hosted production behind external TLS termination.
 HOSTED_PORT="$((PORT_BASE + 10))"
@@ -139,10 +143,11 @@ wait_healthy() {
   local port="$1"
   local url="$2"
   local attempts="$3"
+  local browser_host="${4:-${DOCKER_TEST_BROWSER_HOST}}"
   local attempt
 
   for ((attempt = 0; attempt < attempts; attempt += 1)); do
-    if curl --resolve "${DOCKER_TEST_BROWSER_HOST}:${port}:127.0.0.1" \
+    if curl --resolve "${browser_host}:${port}:127.0.0.1" \
       -kfsS "${url}" >/dev/null 2>&1; then
       return 0
     fi
@@ -555,7 +560,8 @@ fi
 if ! wait_healthy \
   "${PROD_BRIDGE_PORT}" \
   "${PROD_BRIDGE_HEALTH_URL}" \
-  40; then
+  40 \
+  "${PROD_BRIDGE_BROWSER_HOST}"; then
   docker logs "${PROD_BRIDGE_CONTAINER_NAME}" || true
   tail -n 200 "${PROD_BRIDGE_LAUNCH_LOG}" >&2 || true
   echo "Production bridge launcher smoke failed: ${PROD_BRIDGE_HEALTH_URL}" >&2
@@ -571,6 +577,30 @@ if [[ "${prod_bridge_host_ip}" != "127.0.0.1" ]]; then
   exit 1
 fi
 echo "Production bridge launcher is loopback-only."
+
+echo "Running loopback HTTP browser smoke..."
+if ! env \
+  PLAYWRIGHT_BROWSERS_PATH="${PLAYWRIGHT_BROWSERS_DIR}" \
+  REMDO_E2E_HOME_ORIGIN="${PROD_BRIDGE_APP_ORIGIN}" \
+  REMDO_E2E_SOURCE_ORIGIN="${SOURCE_ORIGIN}" \
+  ADMIN_SECRET="${DOCKER_TEST_ADMIN_SECRET}" \
+  YSWEET_SERVER_TOKEN="${DOCKER_TEST_YSWEET_SERVER_TOKEN}" \
+  DATA_DIR="${PROD_BRIDGE_SOURCE_DATA_DIR}" \
+  HOST=localhost \
+  PUBLIC_HOST=localhost \
+  PORT_BASE="${SOURCE_PORT_BASE}" \
+  E2E_WRITE_STORAGE_STATE="${PROD_BRIDGE_AUTH_STATE_PATH}" \
+  E2E_STORAGE_STATE="${PROD_BRIDGE_AUTH_STATE_PATH}" \
+  E2E_WRITE_SMOKE_DOCUMENT_ID="${PROD_BRIDGE_DOCUMENT_ID_PATH}" \
+  E2E_SMOKE_DOCUMENT_ID="${PROD_BRIDGE_DOCUMENT_ID_PATH}" \
+  "${ROOT_DIR}/tools/env.sh" timeout "${TEST_TIMEOUT:-300}s" \
+  pnpm exec playwright test --config playwright.docker.config.ts \
+    tests/e2e/docker/setup.spec.ts; then
+  docker logs "${PROD_BRIDGE_CONTAINER_NAME}" || true
+  echo "Loopback HTTP browser smoke failed: ${PROD_BRIDGE_APP_ORIGIN}" >&2
+  exit 1
+fi
+echo "Loopback HTTP browser smoke OK: ${PROD_BRIDGE_APP_ORIGIN}"
 
 first_prod_bridge_id="$(docker inspect --format '{{.Id}}' "${PROD_BRIDGE_CONTAINER_NAME}")"
 
@@ -591,7 +621,7 @@ for _ in {1..80}; do
   if [[ "${current_prod_bridge_id}" == "${first_prod_bridge_id}" \
     && "${current_restart_count}" =~ ^[0-9]+$ \
     && "${current_restart_count}" -gt "${initial_restart_count}" ]] \
-    && curl --resolve "${DOCKER_TEST_BROWSER_HOST}:${PROD_BRIDGE_PORT}:127.0.0.1" \
+    && curl --resolve "${PROD_BRIDGE_BROWSER_HOST}:${PROD_BRIDGE_PORT}:127.0.0.1" \
       -kfsS "${PROD_BRIDGE_HEALTH_URL}" >/dev/null 2>&1; then
     autoheal_ready=true
     break
@@ -622,7 +652,7 @@ replacement_ready="false"
 for _ in {1..80}; do
   replacement_id="$(docker inspect --format '{{.Id}}' "${PROD_BRIDGE_CONTAINER_NAME}" 2>/dev/null || true)"
   if [[ -n "${replacement_id}" && "${replacement_id}" != "${first_prod_bridge_id}" ]] \
-    && curl --resolve "${DOCKER_TEST_BROWSER_HOST}:${PROD_BRIDGE_PORT}:127.0.0.1" \
+    && curl --resolve "${PROD_BRIDGE_BROWSER_HOST}:${PROD_BRIDGE_PORT}:127.0.0.1" \
       -kfsS "${PROD_BRIDGE_HEALTH_URL}" >/dev/null 2>&1; then
     replacement_ready="true"
     break

--- a/tools/docker-test.sh
+++ b/tools/docker-test.sh
@@ -57,10 +57,7 @@ BOOTSTRAP_DATA_DIR="${TEST_DATA_DIR%/}/bootstrap-home"
 # It uses the next reserved Docker E2E port and a separate container/data dir.
 PROD_BRIDGE_PORT="$((PORT_BASE + 9))"
 remdo_assert_browser_safe_port "${PROD_BRIDGE_PORT}"
-PROD_BRIDGE_BROWSER_HOST="remdo-${PROD_BRIDGE_PORT}.localhost"
 PROD_BRIDGE_CONTAINER_NAME="remdo-${PROD_BRIDGE_PORT}"
-PROD_BRIDGE_APP_ORIGIN="http://${PROD_BRIDGE_BROWSER_HOST}:${PROD_BRIDGE_PORT}"
-PROD_BRIDGE_HEALTH_URL="${PROD_BRIDGE_APP_ORIGIN%/}/health"
 PROD_BRIDGE_DATA_DIR="${TEST_DATA_DIR%/}/prod-bridge-home"
 PROD_BRIDGE_SOURCE_DATA_DIR="${TEST_DATA_DIR%/}/prod-bridge-source"
 PROD_BRIDGE_LAUNCH_LOG="${TEST_DATA_DIR%/}/prod-bridge-launcher.log"
@@ -73,11 +70,21 @@ HOSTED_CONTAINER_NAME="${IMAGE_NAME}-${HOSTED_PORT}"
 HOSTED_APP_ORIGIN="https://remdo.onrender.com"
 HOSTED_DATA_DIR="${TEST_DATA_DIR%/}/hosted-home"
 
+DOCKER_DAEMON_ROOTLESS=false
 if remdo_docker_daemon_is_rootless; then
+  DOCKER_DAEMON_ROOTLESS=true
   remdo_require_rootless_host_network
   DOCKER_RUN_ARGS+=(--userns=host)
 fi
 DOCKER_RUN_ARGS+=(--network=host)
+
+PROD_BRIDGE_BROWSER_HOST="${DOCKER_TEST_BROWSER_HOST}"
+PROD_BRIDGE_APP_ORIGIN="https://${PROD_BRIDGE_BROWSER_HOST}:${PROD_BRIDGE_PORT}"
+if [[ "${DOCKER_DAEMON_ROOTLESS}" == "true" ]]; then
+  PROD_BRIDGE_BROWSER_HOST="remdo-${PROD_BRIDGE_PORT}.localhost"
+  PROD_BRIDGE_APP_ORIGIN="http://${PROD_BRIDGE_BROWSER_HOST}:${PROD_BRIDGE_PORT}"
+fi
+PROD_BRIDGE_HEALTH_URL="${PROD_BRIDGE_APP_ORIGIN%/}/health"
 
 # Wipe a host-mounted data dir from inside the container so container-owned
 # (often root-owned, on a rootful daemon) files are removed by a process with the
@@ -578,29 +585,31 @@ if [[ "${prod_bridge_host_ip}" != "127.0.0.1" ]]; then
 fi
 echo "Production bridge launcher is loopback-only."
 
-echo "Running loopback HTTP browser smoke..."
-if ! env \
-  PLAYWRIGHT_BROWSERS_PATH="${PLAYWRIGHT_BROWSERS_DIR}" \
-  REMDO_E2E_HOME_ORIGIN="${PROD_BRIDGE_APP_ORIGIN}" \
-  REMDO_E2E_SOURCE_ORIGIN="${SOURCE_ORIGIN}" \
-  ADMIN_SECRET="${DOCKER_TEST_ADMIN_SECRET}" \
-  YSWEET_SERVER_TOKEN="${DOCKER_TEST_YSWEET_SERVER_TOKEN}" \
-  DATA_DIR="${PROD_BRIDGE_SOURCE_DATA_DIR}" \
-  HOST=localhost \
-  PUBLIC_HOST=localhost \
-  PORT_BASE="${SOURCE_PORT_BASE}" \
-  E2E_WRITE_STORAGE_STATE="${PROD_BRIDGE_AUTH_STATE_PATH}" \
-  E2E_STORAGE_STATE="${PROD_BRIDGE_AUTH_STATE_PATH}" \
-  E2E_WRITE_SMOKE_DOCUMENT_ID="${PROD_BRIDGE_DOCUMENT_ID_PATH}" \
-  E2E_SMOKE_DOCUMENT_ID="${PROD_BRIDGE_DOCUMENT_ID_PATH}" \
-  "${ROOT_DIR}/tools/env.sh" timeout "${TEST_TIMEOUT:-300}s" \
-  pnpm exec playwright test --config playwright.docker.config.ts \
-    tests/e2e/docker/setup.spec.ts; then
-  docker logs "${PROD_BRIDGE_CONTAINER_NAME}" || true
-  echo "Loopback HTTP browser smoke failed: ${PROD_BRIDGE_APP_ORIGIN}" >&2
-  exit 1
+if [[ "${DOCKER_DAEMON_ROOTLESS}" == "true" ]]; then
+  echo "Running loopback HTTP browser smoke..."
+  if ! env \
+    PLAYWRIGHT_BROWSERS_PATH="${PLAYWRIGHT_BROWSERS_DIR}" \
+    REMDO_E2E_HOME_ORIGIN="${PROD_BRIDGE_APP_ORIGIN}" \
+    REMDO_E2E_SOURCE_ORIGIN="${SOURCE_ORIGIN}" \
+    ADMIN_SECRET="${DOCKER_TEST_ADMIN_SECRET}" \
+    YSWEET_SERVER_TOKEN="${DOCKER_TEST_YSWEET_SERVER_TOKEN}" \
+    DATA_DIR="${PROD_BRIDGE_SOURCE_DATA_DIR}" \
+    HOST=localhost \
+    PUBLIC_HOST=localhost \
+    PORT_BASE="${SOURCE_PORT_BASE}" \
+    E2E_WRITE_STORAGE_STATE="${PROD_BRIDGE_AUTH_STATE_PATH}" \
+    E2E_STORAGE_STATE="${PROD_BRIDGE_AUTH_STATE_PATH}" \
+    E2E_WRITE_SMOKE_DOCUMENT_ID="${PROD_BRIDGE_DOCUMENT_ID_PATH}" \
+    E2E_SMOKE_DOCUMENT_ID="${PROD_BRIDGE_DOCUMENT_ID_PATH}" \
+    "${ROOT_DIR}/tools/env.sh" timeout "${TEST_TIMEOUT:-300}s" \
+    pnpm exec playwright test --config playwright.docker.config.ts \
+      tests/e2e/docker/setup.spec.ts; then
+    docker logs "${PROD_BRIDGE_CONTAINER_NAME}" || true
+    echo "Loopback HTTP browser smoke failed: ${PROD_BRIDGE_APP_ORIGIN}" >&2
+    exit 1
+  fi
+  echo "Loopback HTTP browser smoke OK: ${PROD_BRIDGE_APP_ORIGIN}"
 fi
-echo "Loopback HTTP browser smoke OK: ${PROD_BRIDGE_APP_ORIGIN}"
 
 first_prod_bridge_id="$(docker inspect --format '{{.Id}}' "${PROD_BRIDGE_CONTAINER_NAME}")"
 

--- a/tools/docker-test.sh
+++ b/tools/docker-test.sh
@@ -61,8 +61,6 @@ PROD_BRIDGE_CONTAINER_NAME="remdo-${PROD_BRIDGE_PORT}"
 PROD_BRIDGE_DATA_DIR="${TEST_DATA_DIR%/}/prod-bridge-home"
 PROD_BRIDGE_SOURCE_DATA_DIR="${TEST_DATA_DIR%/}/prod-bridge-source"
 PROD_BRIDGE_LAUNCH_LOG="${TEST_DATA_DIR%/}/prod-bridge-launcher.log"
-PROD_BRIDGE_AUTH_STATE_PATH="${TEST_DATA_DIR%/}/prod-bridge-auth-state.json"
-PROD_BRIDGE_DOCUMENT_ID_PATH="${TEST_DATA_DIR%/}/prod-bridge-document-id.txt"
 
 # Fourth scenario: hosted production behind external TLS termination.
 HOSTED_PORT="$((PORT_BASE + 10))"
@@ -597,10 +595,6 @@ if [[ "${DOCKER_DAEMON_ROOTLESS}" == "true" ]]; then
     HOST=localhost \
     PUBLIC_HOST=localhost \
     PORT_BASE="${SOURCE_PORT_BASE}" \
-    E2E_WRITE_STORAGE_STATE="${PROD_BRIDGE_AUTH_STATE_PATH}" \
-    E2E_STORAGE_STATE="${PROD_BRIDGE_AUTH_STATE_PATH}" \
-    E2E_WRITE_SMOKE_DOCUMENT_ID="${PROD_BRIDGE_DOCUMENT_ID_PATH}" \
-    E2E_SMOKE_DOCUMENT_ID="${PROD_BRIDGE_DOCUMENT_ID_PATH}" \
     "${ROOT_DIR}/tools/env.sh" timeout "${TEST_TIMEOUT:-300}s" \
     pnpm exec playwright test --config playwright.docker.config.ts \
       tests/e2e/docker/setup.spec.ts; then

--- a/tools/prod/docker.sh
+++ b/tools/prod/docker.sh
@@ -32,12 +32,33 @@ case "${HOST}" in
     exit 1
     ;;
 esac
+LOOPBACK_HTTP=false
+if [[ "${APP_ORIGIN}" == http://* ]]; then
+  if [[ ! "${APP_ORIGIN}" =~ ^http://([a-z0-9-]+\.)+localhost:([0-9]+)$ ]]; then
+    echo "HTTP APP_ORIGIN must be an exact *.localhost origin with an explicit port." >&2
+    exit 1
+  fi
+  if [[ "${HOST}" != "127.0.0.1" ]]; then
+    echo "HTTP APP_ORIGIN requires HOST=127.0.0.1." >&2
+    exit 1
+  fi
+  LOOPBACK_HTTP=true
+fi
 if [[ "${HOST}" == "0.0.0.0" && "${PORT}" != "443" ]]; then
   echo "HOST=0.0.0.0 requires APP_ORIGIN to use the default HTTPS port 443." >&2
   exit 1
 fi
 remdo_load_env_defaults "${ROOT_DIR}"
 remdo_assert_browser_safe_port "${PORT}"
+
+if [[ "${LOOPBACK_HTTP}" == "true" ]]; then
+  docker_server_version="$(docker version --format '{{.Server.Version}}')"
+  docker_server_major="${docker_server_version%%.*}"
+  if (( docker_server_major < 28 )); then
+    echo "Loopback HTTP requires Docker Engine 28.0 or newer (found ${docker_server_version})." >&2
+    exit 1
+  fi
+fi
 
 # Operators set only ADMIN_SECRET (never auto-generated). AUTH_SECRET and the
 # Y-Sweet auth_key/server_token pair are bootstrapped inside the container from
@@ -76,6 +97,9 @@ DOCKER_ENV_ARGS=(
   -e APP_ORIGIN="${APP_ORIGIN}"
   -e ALLOW_SIGNUP="${ALLOW_SIGNUP}"
 )
+if [[ "${LOOPBACK_HTTP}" == "true" ]]; then
+  DOCKER_ENV_ARGS+=(-e REMDO_LAUNCHER_LOOPBACK_HTTP=true)
+fi
 
 # Forward bootstrap-managed secrets only when the operator set them explicitly,
 # so empty values never shadow the in-container bootstrap.

--- a/tools/prod/docker.sh
+++ b/tools/prod/docker.sh
@@ -52,6 +52,10 @@ remdo_load_env_defaults "${ROOT_DIR}"
 remdo_assert_browser_safe_port "${PORT}"
 
 if [[ "${LOOPBACK_HTTP}" == "true" ]]; then
+  if ! remdo_docker_daemon_is_rootless; then
+    echo "Loopback HTTP requires a rootless Docker daemon." >&2
+    exit 1
+  fi
   docker_server_version="$(docker version --format '{{.Server.Version}}')"
   docker_server_major="${docker_server_version%%.*}"
   if (( docker_server_major < 28 )); then


### PR DESCRIPTION
…— add strict HTTP origin gating in entrypoint and launcher with Docker 28 checks plus docs and test coverage