### PR TITLE
test(eslint): assert every editor directory is in the boundary graph

### DIFF
--- a/config/eslint/editorBoundaries.ts
+++ b/config/eslint/editorBoundaries.ts
@@ -1,4 +1,6 @@
-// Element and policy configuration for `eslint-plugin-boundaries`.
+// Enforces which parts of the editor may import which, one import at a time.
+// It reasons about folders, not files, so a mutual edge here can still be an
+// acyclic chain — `pnpm run lint:deps` owns cycles.
 const EDITOR = 'src/client/editor';
 
 // Limits classification to the editor. Without it every import reaching outside

--- a/tests/unit/editor-boundaries.spec.ts
+++ b/tests/unit/editor-boundaries.spec.ts
@@ -1,0 +1,26 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { boundariesElements } from '../../config/eslint/editorBoundaries';
+
+const EDITOR = path.resolve('src/client/editor');
+
+describe('editor boundaries', () => {
+  // An unlisted directory falls through to the `editor-root` catch-all and
+  // inherits its allowances, so it raises no lint error however it imports.
+  // Failing here is what prompts placing a new directory in the graph.
+  it('lists every directory under the editor', () => {
+    const declared = new Set(
+      boundariesElements
+        .map((element) => path.relative(EDITOR, path.resolve(element.pattern)))
+        .filter((relative) => relative.length > 0)
+    );
+
+    const present = fs
+      .readdirSync(EDITOR, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name);
+
+    expect(present.filter((name) => !declared.has(name))).toEqual([]);
+  });
+});


### PR DESCRIPTION
An unlisted directory falls through to the `editor-root` catch-all and inherits its allowances, so it raises no violation however it imports — the lint rules structurally cannot see it. Comparing the element list against the filesystem can, and failing here is what prompts placing a new directory in the graph.

Also states what the boundaries config governs and where its authority stops: it groups files into folders, so two folders can each appear to import the other while the underlying files form an acyclic chain — `lint:deps` owns cycles.