### PR TITLE
fix(auth): keep every sharing tab signed out from the pending marker

### DIFF
--- a/src/client/app/session/client.spec.ts
+++ b/src/client/app/session/client.spec.ts
@@ -16,6 +16,7 @@ describe('auth client session gate', () => {
     getSessionMock.mockReset();
     signOutMock.mockReset();
     localStorage.clear();
+    sessionStorage.clear();
     Object.defineProperty(navigator, 'onLine', {
       configurable: true,
       value: true,
@@ -125,16 +126,33 @@ describe('auth client session gate', () => {
     expect(localStorage.getItem('remdo-current-user-bootstrap')).toBeNull();
   });
 
-  it('clears a pending sign-out once the server confirms it', async () => {
+  it('exposes the pending-sign-out write as a storage event peers can observe', async () => {
+    const {
+      isPendingSignOutStorageEvent,
+      PENDING_SIGN_OUT_STORAGE_KEY,
+      rememberPendingSignOut,
+    } = await import('#client/app/session/client');
+
+    rememberPendingSignOut();
+
+    expect(isPendingSignOutStorageEvent(new StorageEvent('storage', {
+      key: PENDING_SIGN_OUT_STORAGE_KEY,
+      newValue: localStorage.getItem(PENDING_SIGN_OUT_STORAGE_KEY),
+    }))).toBe(true);
+  });
+
+  it('does not resume a session after the server confirms sign-out', async () => {
     signOutMock.mockResolvedValue({ data: { success: true }, error: null });
+    getSessionMock.mockResolvedValue({ data: { user: { id: 'user1' } } });
     localStorage.setItem('remdo-pending-sign-out', '1');
     const { resolveSessionGateState } = await import('#client/app/session/client');
 
     await expect(resolveSessionGateState()).resolves.toEqual({ status: 'unauthenticated' });
+    await expect(resolveSessionGateState()).resolves.toEqual({ status: 'unauthenticated' });
 
-    expect(signOutMock).toHaveBeenCalledTimes(1);
+    expect(signOutMock).toHaveBeenCalledTimes(2);
     expect(getSessionMock).not.toHaveBeenCalled();
-    expect(localStorage.getItem('remdo-pending-sign-out')).toBeNull();
+    expect(localStorage.getItem('remdo-pending-sign-out')).toBe('1');
   });
 
   it('does not resume a session whose sign-out the server has not confirmed', async () => {

--- a/src/client/app/session/client.spec.ts
+++ b/src/client/app/session/client.spec.ts
@@ -126,6 +126,20 @@ describe('auth client session gate', () => {
     expect(localStorage.getItem('remdo-current-user-bootstrap')).toBeNull();
   });
 
+  it('still writes the shared pending marker when tab storage rejects the origin mark', async () => {
+    const { PENDING_SIGN_OUT_STORAGE_KEY, rememberPendingSignOut } = await import('#client/app/session/client');
+    const setItem = vi.spyOn(sessionStorage, 'setItem').mockImplementation(() => {
+      throw new DOMException('The quota has been exceeded.', 'QuotaExceededError');
+    });
+
+    try {
+      expect(() => rememberPendingSignOut()).not.toThrow();
+      expect(localStorage.getItem(PENDING_SIGN_OUT_STORAGE_KEY)).toBe('1');
+    } finally {
+      setItem.mockRestore();
+    }
+  });
+
   it('exposes the pending-sign-out write as a storage event peers can observe', async () => {
     const {
       isPendingSignOutStorageEvent,

--- a/src/client/app/session/client.ts
+++ b/src/client/app/session/client.ts
@@ -3,7 +3,9 @@ import { createAuthClient } from 'better-auth/react';
 import { clearStoredCurrentUserBootstrap } from '#client/app/user-data/current-user-bootstrap-storage';
 
 const KNOWN_SESSION_STORAGE_KEY = 'remdo-authenticated-session';
-const PENDING_SIGN_OUT_STORAGE_KEY = 'remdo-pending-sign-out';
+export const PENDING_SIGN_OUT_STORAGE_KEY = 'remdo-pending-sign-out';
+const PENDING_SIGN_OUT_ORIGIN_KEY = 'remdo-pending-sign-out-origin';
+const PENDING_SIGN_OUT_STORAGE_VALUE = '1';
 const SERVER_SIGN_OUT_TIMEOUT_MS = 1500;
 
 export const authClient = createAuthClient({
@@ -28,6 +30,14 @@ function getSessionStorage(): Storage | null {
   }
 }
 
+function getTabStorage(): Storage | null {
+  try {
+    return globalThis.sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
 export function rememberAuthenticatedSession() {
   getSessionStorage()?.setItem(KNOWN_SESSION_STORAGE_KEY, '1');
   // A fresh session supersedes any sign-out this device never delivered;
@@ -47,24 +57,37 @@ export function hasRememberedSession() {
 /**
  * A sign-out that could not reach the server leaves the session cookie valid, so
  * the next reachable revalidation would sign the user back in. The marker keeps
- * this device signed out until the server confirms, and is cleared by any
- * successful sign-in.
+ * this device signed out until a successful sign-in, including after the server
+ * has confirmed the revoke.
  */
 export function rememberPendingSignOut() {
-  getSessionStorage()?.setItem(PENDING_SIGN_OUT_STORAGE_KEY, '1');
+  // Mark this tab first so its own peer-sign-out poll does not treat the write
+  // as another tab's broadcast.
+  getTabStorage()?.setItem(PENDING_SIGN_OUT_ORIGIN_KEY, PENDING_SIGN_OUT_STORAGE_VALUE);
+  getSessionStorage()?.setItem(PENDING_SIGN_OUT_STORAGE_KEY, PENDING_SIGN_OUT_STORAGE_VALUE);
 }
 
 export function forgetPendingSignOut() {
   getSessionStorage()?.removeItem(PENDING_SIGN_OUT_STORAGE_KEY);
+  getTabStorage()?.removeItem(PENDING_SIGN_OUT_ORIGIN_KEY);
 }
 
 export function hasPendingSignOut() {
-  return getSessionStorage()?.getItem(PENDING_SIGN_OUT_STORAGE_KEY) === '1';
+  return getSessionStorage()?.getItem(PENDING_SIGN_OUT_STORAGE_KEY) === PENDING_SIGN_OUT_STORAGE_VALUE;
+}
+
+export function originatedPendingSignOut() {
+  return getTabStorage()?.getItem(PENDING_SIGN_OUT_ORIGIN_KEY) === PENDING_SIGN_OUT_STORAGE_VALUE;
+}
+
+export function isPendingSignOutStorageEvent(event: StorageEvent): boolean {
+  return event.key === PENDING_SIGN_OUT_STORAGE_KEY
+    && event.newValue === PENDING_SIGN_OUT_STORAGE_VALUE;
 }
 
 /**
- * Revoke the server session. The pending marker stays until the server confirms;
- * a `{ error }` result is not confirmation.
+ * Revoke the server session. The pending marker stays until a successful
+ * sign-in; a `{ error }` result is not confirmation.
  */
 export async function revokeServerSession(): Promise<void> {
   try {
@@ -77,7 +100,6 @@ export async function revokeServerSession(): Promise<void> {
     if (result.error) {
       throw result.error;
     }
-    forgetPendingSignOut();
   } catch {
     rememberPendingSignOut();
   }

--- a/src/client/app/session/client.ts
+++ b/src/client/app/session/client.ts
@@ -62,8 +62,13 @@ export function hasRememberedSession() {
  */
 export function rememberPendingSignOut() {
   // Mark this tab first so its own peer-sign-out poll does not treat the write
-  // as another tab's broadcast.
-  getTabStorage()?.setItem(PENDING_SIGN_OUT_ORIGIN_KEY, PENDING_SIGN_OUT_STORAGE_VALUE);
+  // as another tab's broadcast. Session storage is best-effort: a quota or
+  // permission failure must not skip the shared marker or abort logout.
+  try {
+    getTabStorage()?.setItem(PENDING_SIGN_OUT_ORIGIN_KEY, PENDING_SIGN_OUT_STORAGE_VALUE);
+  } catch {
+    // Originator mark is optional; peers still see the shared localStorage key.
+  }
   getSessionStorage()?.setItem(PENDING_SIGN_OUT_STORAGE_KEY, PENDING_SIGN_OUT_STORAGE_VALUE);
 }
 

--- a/src/client/app/session/logout-broadcast.spec.ts
+++ b/src/client/app/session/logout-broadcast.spec.ts
@@ -35,6 +35,49 @@ describe('logout broadcast', () => {
     vi.advanceTimersByTime(50);
 
     expect(onSignOut).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(500);
+    expect(onSignOut).toHaveBeenCalledTimes(1);
+    unsubscribe();
+  });
+
+  it('delivers a later peer sign-out after this tab signs in again', () => {
+    vi.useFakeTimers();
+    localStorage.setItem(PENDING_SIGN_OUT_STORAGE_KEY, '1');
+    const onSignOut = vi.fn();
+    const unsubscribe = subscribeToSignOut(onSignOut);
+
+    vi.advanceTimersByTime(50);
+    expect(onSignOut).toHaveBeenCalledTimes(1);
+
+    localStorage.removeItem(PENDING_SIGN_OUT_STORAGE_KEY);
+    vi.advanceTimersByTime(50);
+    localStorage.setItem(PENDING_SIGN_OUT_STORAGE_KEY, '1');
+    vi.advanceTimersByTime(50);
+
+    expect(onSignOut).toHaveBeenCalledTimes(2);
+    unsubscribe();
+  });
+
+  it('re-arms when a storage event clears the pending marker', () => {
+    const onSignOut = vi.fn();
+    const unsubscribe = subscribeToSignOut(onSignOut);
+
+    window.dispatchEvent(new StorageEvent('storage', {
+      key: PENDING_SIGN_OUT_STORAGE_KEY,
+      newValue: '1',
+    }));
+    expect(onSignOut).toHaveBeenCalledTimes(1);
+
+    window.dispatchEvent(new StorageEvent('storage', {
+      key: PENDING_SIGN_OUT_STORAGE_KEY,
+      newValue: null,
+    }));
+    window.dispatchEvent(new StorageEvent('storage', {
+      key: PENDING_SIGN_OUT_STORAGE_KEY,
+      newValue: '1',
+    }));
+
+    expect(onSignOut).toHaveBeenCalledTimes(2);
     unsubscribe();
   });
 

--- a/src/client/app/session/logout-broadcast.spec.ts
+++ b/src/client/app/session/logout-broadcast.spec.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  PENDING_SIGN_OUT_STORAGE_KEY,
+  rememberPendingSignOut,
+} from './client';
+import { subscribeToSignOut } from './logout-broadcast';
+
+describe('logout broadcast', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    localStorage.clear();
+    sessionStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it('notifies a peer when the originating tab writes the pending-sign-out marker', () => {
+    const onSignOut = vi.fn();
+    const unsubscribe = subscribeToSignOut(onSignOut);
+
+    window.dispatchEvent(new StorageEvent('storage', {
+      key: PENDING_SIGN_OUT_STORAGE_KEY,
+      newValue: '1',
+    }));
+
+    expect(onSignOut).toHaveBeenCalledTimes(1);
+    unsubscribe();
+  });
+
+  it('notifies a peer that observes the pending marker without a storage event', () => {
+    vi.useFakeTimers();
+    localStorage.setItem(PENDING_SIGN_OUT_STORAGE_KEY, '1');
+    const onSignOut = vi.fn();
+    const unsubscribe = subscribeToSignOut(onSignOut);
+
+    vi.advanceTimersByTime(50);
+
+    expect(onSignOut).toHaveBeenCalledTimes(1);
+    unsubscribe();
+  });
+
+  it('does not treat the originating tab as a peer', () => {
+    vi.useFakeTimers();
+    rememberPendingSignOut();
+    const onSignOut = vi.fn();
+    const unsubscribe = subscribeToSignOut(onSignOut);
+
+    vi.advanceTimersByTime(500);
+
+    expect(onSignOut).not.toHaveBeenCalled();
+    unsubscribe();
+  });
+
+  it('ignores unrelated storage writes', () => {
+    const onSignOut = vi.fn();
+    const unsubscribe = subscribeToSignOut(onSignOut);
+
+    window.dispatchEvent(new StorageEvent('storage', {
+      key: PENDING_SIGN_OUT_STORAGE_KEY,
+      newValue: null,
+    }));
+    window.dispatchEvent(new StorageEvent('storage', {
+      key: 'remdo-authenticated-session',
+      newValue: '1',
+    }));
+
+    expect(onSignOut).not.toHaveBeenCalled();
+    unsubscribe();
+  });
+});

--- a/src/client/app/session/logout-broadcast.ts
+++ b/src/client/app/session/logout-broadcast.ts
@@ -1,4 +1,5 @@
 import {
+  PENDING_SIGN_OUT_STORAGE_KEY,
   hasPendingSignOut,
   isPendingSignOutStorageEvent,
   originatedPendingSignOut,
@@ -13,26 +14,37 @@ const PEER_SIGN_OUT_POLL_MS = 50;
  * marker and skip the tab that wrote it.
  */
 export function subscribeToSignOut(onSignOut: () => void): () => void {
+  // LogoutProvider stays mounted through sign-in, so this latch must clear when
+  // the marker is gone or a later peer logout is ignored.
   let delivered = false;
-  let pollId = 0;
   const deliver = () => {
     if (delivered) {
       return;
     }
     delivered = true;
-    window.clearInterval(pollId);
     onSignOut();
+  };
+  const rearm = () => {
+    delivered = false;
   };
 
   const onStorage = (event: StorageEvent) => {
     if (isPendingSignOutStorageEvent(event)) {
       deliver();
+      return;
+    }
+    if (event.key === PENDING_SIGN_OUT_STORAGE_KEY || event.key === null) {
+      rearm();
     }
   };
   window.addEventListener('storage', onStorage);
 
-  pollId = window.setInterval(() => {
-    if (hasPendingSignOut() && !originatedPendingSignOut()) {
+  const pollId = window.setInterval(() => {
+    if (!hasPendingSignOut()) {
+      rearm();
+      return;
+    }
+    if (!originatedPendingSignOut()) {
       deliver();
     }
   }, PEER_SIGN_OUT_POLL_MS);

--- a/src/client/app/session/logout-broadcast.ts
+++ b/src/client/app/session/logout-broadcast.ts
@@ -1,42 +1,44 @@
-import { getGlobalBroadcastChannel } from 'better-auth/client';
+import {
+  hasPendingSignOut,
+  isPendingSignOutStorageEvent,
+  originatedPendingSignOut,
+} from './client';
+
+const PEER_SIGN_OUT_POLL_MS = 50;
 
 /**
- * Better Auth broadcasts a sign-out to its other tabs, but only from a
- * successful response, so an offline or failed sign-out never reaches them.
- * Posting the same message ourselves covers that case on the channel Better
- * Auth already listens to.
- *
- * `getGlobalBroadcastChannel` is exported but undocumented, so every use of it
- * goes through this module.
+ * Other tabs learn of a sign-out from the pending-sign-out marker the
+ * originating tab writes. A `storage` event is the prompt path; some browsers
+ * omit that event between same-origin tabs, so peers also poll the shared
+ * marker and skip the tab that wrote it.
  */
-export function broadcastSignOut(): void {
-  try {
-    getGlobalBroadcastChannel().post({
-      event: 'session',
-      data: { trigger: 'signout' },
-      clientId: crypto.randomUUID(),
-    });
-  } catch {
-    // A tab that cannot broadcast still signs itself out.
-  }
-}
-
 export function subscribeToSignOut(onSignOut: () => void): () => void {
-  try {
-    const channel = getGlobalBroadcastChannel();
-    // Messages arrive as `storage` events, which only fire once `setup()` has
-    // attached its listener.
-    const teardownChannel = channel.setup();
-    const unsubscribe = channel.subscribe((message) => {
-      if (message.data?.trigger === 'signout') {
-        onSignOut();
-      }
-    });
-    return () => {
-      unsubscribe();
-      teardownChannel();
-    };
-  } catch {
-    return () => {};
-  }
+  let delivered = false;
+  let pollId = 0;
+  const deliver = () => {
+    if (delivered) {
+      return;
+    }
+    delivered = true;
+    window.clearInterval(pollId);
+    onSignOut();
+  };
+
+  const onStorage = (event: StorageEvent) => {
+    if (isPendingSignOutStorageEvent(event)) {
+      deliver();
+    }
+  };
+  window.addEventListener('storage', onStorage);
+
+  pollId = window.setInterval(() => {
+    if (hasPendingSignOut() && !originatedPendingSignOut()) {
+      deliver();
+    }
+  }, PEER_SIGN_OUT_POLL_MS);
+
+  return () => {
+    window.removeEventListener('storage', onStorage);
+    window.clearInterval(pollId);
+  };
 }

--- a/src/client/app/session/unsynced-logout.spec.tsx
+++ b/src/client/app/session/unsynced-logout.spec.tsx
@@ -1,11 +1,12 @@
 import { MantineProvider } from '@mantine/core';
-import { fireEvent, render, within } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import type { ReactNode } from 'react';
+import { act, fireEvent, render, waitFor, within } from '@testing-library/react';
+import { MemoryRouter, useLocation } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { hasUnsyncedLocalChanges } from '#collaboration/unsynced-local-changes';
 import { resetUserData } from '#client/app/user-data/user-data';
 import { forgetAuthenticatedSession } from './client';
-import { LogoutProvider, useLogout } from './useLogout';
+import { LOGGED_OUT_STATE_KEY, LogoutProvider, useLogout } from './useLogout';
 import { logoutCurrentUser } from './logout';
 import UnsyncedLogoutDialog from '#client/ui/UnsyncedLogoutDialog';
 
@@ -28,7 +29,6 @@ vi.mock('./logout', () => ({
 let deliverPeerSignOut: (() => void) | undefined;
 
 vi.mock('./logout-broadcast', () => ({
-  broadcastSignOut: vi.fn(),
   subscribeToSignOut: vi.fn((onSignOut: () => void) => {
     deliverPeerSignOut = onSignOut;
     return () => {
@@ -56,7 +56,12 @@ function SecondLogoutCaller() {
   return <button onClick={logout.requestLogout} type="button">Logout elsewhere</button>;
 }
 
-function renderHarness() {
+function LocationState() {
+  const location = useLocation();
+  return <output>{JSON.stringify(location.state)}</output>;
+}
+
+function renderHarness(extra?: ReactNode) {
   // The shared jsdom document already hosts a mounted editor, so queries are
   // scoped to this render's own container rather than the whole body.
   const container = document.createElement('div');
@@ -66,6 +71,7 @@ function renderHarness() {
       <MemoryRouter>
         <LogoutProvider>
           <LogoutHarness />
+          {extra}
         </LogoutProvider>
       </MemoryRouter>
     </MantineProvider>,
@@ -149,10 +155,17 @@ describe('logout with unsynced local edits', () => {
     expect(logoutCurrentUser).toHaveBeenCalledTimes(1);
   });
 
-  it('tears a peer tab down without repeating the originating wipe', () => {
-    renderHarness();
-    deliverPeerSignOut?.();
+  it('sends a peer tab to the signed-out location without repeating the wipe', async () => {
+    const { ui } = renderHarness(<LocationState />);
+    act(() => {
+      deliverPeerSignOut?.();
+    });
 
+    await waitFor(() => {
+      expect(ui.getByRole('status')).toHaveTextContent(
+        JSON.stringify({ [LOGGED_OUT_STATE_KEY]: true }),
+      );
+    });
     expect(resetUserData).toHaveBeenCalledTimes(1);
     expect(forgetAuthenticatedSession).toHaveBeenCalledTimes(1);
     expect(logoutCurrentUser).not.toHaveBeenCalled();

--- a/src/client/app/session/useLogout.tsx
+++ b/src/client/app/session/useLogout.tsx
@@ -5,7 +5,7 @@ import { resetUserData } from '#client/app/user-data/user-data';
 import { hasUnsyncedLocalChanges } from '#collaboration/unsynced-local-changes';
 import { forgetAuthenticatedSession } from './client';
 import { logoutCurrentUser } from './logout';
-import { broadcastSignOut, subscribeToSignOut } from './logout-broadcast';
+import { subscribeToSignOut } from './logout-broadcast';
 
 export const LOGGED_OUT_STATE_KEY = 'loggedOut';
 
@@ -38,9 +38,8 @@ function useLogoutController(): LogoutController {
   const [confirmingLoss, setConfirmingLoss] = useState(false);
 
   const signOut = useCallback(async () => {
-    // Peers tear down while this tab is still healthy, before its own storage
-    // and session go away.
-    broadcastSignOut();
+    // `logoutCurrentUser` writes the pending-sign-out marker first, so peers
+    // tear down while this tab is still healthy.
     await logoutCurrentUser();
     await navigate('/', { replace: true, state: { [LOGGED_OUT_STATE_KEY]: true } });
   }, [navigate]);
@@ -69,7 +68,7 @@ function useLogoutController(): LogoutController {
     // before a further edit hits a provider whose database is already going away.
     resetUserData();
     forgetAuthenticatedSession();
-    void navigate('/', { replace: true });
+    void navigate('/', { replace: true, state: { [LOGGED_OUT_STATE_KEY]: true } });
   }), [navigate]);
 
   return { confirmingLoss, requestLogout, confirmLogout, cancelLogout };

--- a/tests/e2e/_support/fixtures.ts
+++ b/tests/e2e/_support/fixtures.ts
@@ -26,6 +26,20 @@ interface ConsoleIssuePatternOptions {
 }
 
 const issueExpectationsByPage = new WeakMap<Page, ConsoleIssueMatchers>();
+const allowedResponseStatusesByPage = new WeakMap<Page, Set<number>>();
+
+function allowResponseStatuses(page: Page, statuses: number[]): void {
+  const allowed = allowedResponseStatusesByPage.get(page) ?? new Set();
+  for (const status of statuses) {
+    allowed.add(status);
+  }
+  allowedResponseStatusesByPage.set(page, allowed);
+}
+
+export function allowUnauthorizedNetwork(page: Page): void {
+  allowResponseStatuses(page, [HTTP_STATUS.UNAUTHORIZED]);
+  setExpectedConsoleIssues(page, ['401'], { mode: 'allowContains' });
+}
 
 function createIssueCounts(messages: string[]): Map<string, number> {
   const counts = new Map<string, number>();
@@ -131,6 +145,9 @@ export function attachPageGuards(page: Page): (verifyExpectedIssues?: boolean) =
 
   const onResponse = (response: Response) => {
     const status = response.status();
+    if (allowedResponseStatusesByPage.get(page)?.has(status)) {
+      return;
+    }
     if (status >= HTTP_STATUS.BAD_REQUEST && !allowResponse(response)) {
       throw new Error(`response ${status}: ${response.url()}`);
     }
@@ -146,6 +163,7 @@ export function attachPageGuards(page: Page): (verifyExpectedIssues?: boolean) =
     const outstandingContains = expected ? [...expected.containsCounts.entries()] : [];
     const outstanding = [...outstandingExact, ...outstandingContains];
     issueExpectationsByPage.delete(page);
+    allowedResponseStatusesByPage.delete(page);
     page.off('console', onConsole);
     page.off('pageerror', onPageError);
     page.off('response', onResponse);

--- a/tests/e2e/app/routing.spec.ts
+++ b/tests/e2e/app/routing.spec.ts
@@ -1,4 +1,10 @@
-import { collectCurrentUserRequests, expect, test, unauthenticatedTest } from '#e2e/fixtures';
+import {
+  allowUnauthorizedNetwork,
+  collectCurrentUserRequests,
+  expect,
+  test,
+  unauthenticatedTest,
+} from '#e2e/fixtures';
 import type { Page } from '#e2e/fixtures';
 import type { CurrentUserBootstrap } from '#domain/documents/user-data';
 import { HTTP_STATUS } from '#platform/http/status';
@@ -128,6 +134,7 @@ test.describe('Routing', () => {
     await createIndexedDb(page, 'y-sweet-logout-test');
     const navigations = await countNavigations(page);
 
+    allowUnauthorizedNetwork(page);
     await page.getByRole('button', { name: 'Logout' }).click();
 
     await expectPath(page, '/');
@@ -148,12 +155,14 @@ test.describe('Routing', () => {
     await peer.goto('/');
     await expect(peer.locator('.collab-status')).toHaveAttribute('aria-label', /Server connected/i);
 
+    allowUnauthorizedNetwork(page);
     await page.getByRole('button', { name: 'Logout' }).click();
 
     // The peer stops using its local data as soon as the broadcast lands; the
     // login view follows a loader round-trip, so allow for a slow one.
     await expect(peer.getByRole('button', { name: 'Logout' })).toBeHidden({ timeout: 15_000 });
     await expect(peer.getByRole('heading', { level: 1, name: 'Sign in' })).toBeVisible({ timeout: 15_000 });
+    await expect(peer.getByRole('status')).toContainText(/signed out/i);
     await peer.close();
   });
 });


### PR DESCRIPTION
Peers watch the pending-sign-out localStorage write instead of Better Auth's session channel, and poll when the storage event is dropped. The marker now lasts until the next sign-in so a still-visible cookie cannot restore the session after revoke.