### PR TITLE
refactor: give search its own path type

### DIFF
--- a/src/client/app/workspace/SearchResultRow.tsx
+++ b/src/client/app/workspace/SearchResultRow.tsx
@@ -1,6 +1,6 @@
 import { Fragment } from 'react';
 import type { MouseEvent as ReactMouseEvent } from 'react';
-import type { NotePathItem } from '#client/editor/view/workspace';
+import type { SearchPathItem } from '#client/editor/view/workspace';
 import type { NoteListType } from '#note-sdk';
 import { queryMatchRanges } from '#client/search/query-match';
 import { UNTITLED_LABEL, formatNavigationLabel, normalizeNavigationLabel } from '#client/ui/navigation-label';
@@ -13,7 +13,7 @@ interface ChildPreviewItem {
 }
 
 interface SearchResultRowProps {
-  ancestorPath: NotePathItem[];
+  ancestorPath: SearchPathItem[];
   checked: boolean;
   childPreview: ChildPreviewItem[];
   childCount: number;
@@ -26,7 +26,7 @@ const BREADCRUMB_VISIBLE_LIMIT = 4;
 const BREADCRUMB_EDGE_COUNT = 2;
 
 type BreadcrumbCrumb =
-  | { kind: 'note'; item: NotePathItem }
+  | { kind: 'note'; item: SearchPathItem }
   | { kind: 'ellipsis'; hiddenLabels: string[] };
 
 // Builds the ancestor subline crumbs for a match. The matched note (the last
@@ -34,7 +34,7 @@ type BreadcrumbCrumb =
 // full ancestor chain (including the top-level note) is shown for context. A deep
 // chain collapses to first/last edges joined by a single ellipsis crumb; width
 // truncation of individual crumbs is handled in CSS, not here.
-function buildBreadcrumbCrumbs(ancestorPath: NotePathItem[]): BreadcrumbCrumb[] {
+function buildBreadcrumbCrumbs(ancestorPath: SearchPathItem[]): BreadcrumbCrumb[] {
   // Ancestors only — drop the matched note (the primary label), keep the rest.
   const path = ancestorPath.slice(0, -1);
 
@@ -102,7 +102,7 @@ function ResultBreadcrumb({
   onSelectAncestor,
   query,
 }: {
-  ancestorPath: NotePathItem[];
+  ancestorPath: SearchPathItem[];
   onSelectAncestor: (event: ReactMouseEvent<HTMLElement>, noteId: string) => void;
   query: string;
 }) {

--- a/src/client/app/workspace/document/DocumentSearch.tsx
+++ b/src/client/app/workspace/document/DocumentSearch.tsx
@@ -1,6 +1,6 @@
 import { TextInput } from '@mantine/core';
 import { IconSearch } from '@tabler/icons-react';
-import type { NotePathItem } from '#client/editor/view/workspace';
+import type { SearchPathItem } from '#client/editor/view/workspace';
 import {
   UNTITLED_LABEL,
   normalizeNavigationLabel,
@@ -8,7 +8,7 @@ import {
 import { SearchResultRow } from '../SearchResultRow';
 import type { DocumentSearchModel } from '../useDocumentSearchModel';
 
-function buildSearchResultAccessibleName(text: string, path: NotePathItem[]): string {
+function buildSearchResultAccessibleName(text: string, path: SearchPathItem[]): string {
   const name = normalizeNavigationLabel(text) || UNTITLED_LABEL;
   const ancestors = path.slice(0, -1);
   if (ancestors.length === 0) {

--- a/src/client/app/workspace/search-result-row.spec.tsx
+++ b/src/client/app/workspace/search-result-row.spec.tsx
@@ -1,9 +1,9 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
-import type { NotePathItem } from '#client/editor/view/workspace';
+import type { SearchPathItem } from '#client/editor/view/workspace';
 import { SearchResultRow } from '#client/app/workspace/SearchResultRow';
 
-const ancestorPath: NotePathItem[] = [
+const ancestorPath: SearchPathItem[] = [
   { noteId: 'root', label: 'Work' },
   { noteId: 'mid', label: 'Q3 planning' },
   { noteId: 'mid2', label: 'Roadmap' },
@@ -26,7 +26,7 @@ function renderRow({
   query = 'refine',
   text = 'TODO refine estimates',
 }: {
-  path?: NotePathItem[];
+  path?: SearchPathItem[];
   checked?: boolean;
   children?: typeof childPreview;
   childCount?: number;

--- a/src/client/editor/features/search/search-candidates.ts
+++ b/src/client/editor/features/search/search-candidates.ts
@@ -1,6 +1,10 @@
 import type { NoteListType } from '#note-sdk';
-import type { NotePathItem } from '#client/editor/outline/note-traversal';
 import { matchesPathQuery } from '#client/search/query-match';
+
+export interface SearchPathItem {
+  noteId: string;
+  label: string;
+}
 
 /** A note's render-relevant fields, used for the child preview. */
 interface ChildCandidate {
@@ -14,7 +18,7 @@ interface ChildCandidate {
  *  self last) for matching and result context. */
 export interface SearchCandidate extends ChildCandidate {
   childPreview: ChildPreview;
-  path: NotePathItem[];
+  path: SearchPathItem[];
 }
 
 /** The first few direct children of a result (for the row preview) plus the
@@ -66,7 +70,7 @@ function toChildCandidate(note: SearchableNote): ChildCandidate {
 
 interface CandidateWalkEntry {
   note: SearchableNote;
-  ancestorPath: NotePathItem[];
+  ancestorPath: SearchPathItem[];
 }
 
 /**

--- a/src/client/editor/view/workspace.ts
+++ b/src/client/editor/view/workspace.ts
@@ -1,5 +1,10 @@
 export type { NotePathItem } from '#client/editor/outline/note-traversal';
 export { ZoomBreadcrumbs } from '#client/editor/features/zoom/ZoomBreadcrumbs';
 export { collectDocumentSearchResults } from '#client/editor/features/search/search-candidates';
-export type { SearchCandidate } from '#client/editor/features/search/search-candidates';
+export type {
+  SearchCandidate,
+  SearchPathItem,
+  SearchableNote,
+  SearchableNotes,
+} from '#client/editor/features/search/search-candidates';
 export { registerPendingDocumentImport } from '#client/editor/runtime/pending-document-import';

--- a/tests/unit/_support/document-route-harness.tsx
+++ b/tests/unit/_support/document-route-harness.tsx
@@ -5,11 +5,11 @@ import * as React from 'react';
 import { createMemoryRouter, RouterProvider } from 'react-router-dom';
 import { vi } from 'vitest';
 import { resetTestUserData, TEST_USER_DATA_DOCUMENT } from '#tests';
-import type { NotePathItem } from '#client/editor/view/workspace';
 import type {
+  NotePathItem,
   SearchableNote,
   SearchableNotes,
-} from '#client/editor/features/search/search-candidates';
+} from '#client/editor/view/workspace';
 import {
   useEditorViewActions,
   useRegisterSearchNotesReader,


### PR DESCRIPTION
Query matching stays in client/search; candidate collection stays in features/search. Search rows no longer use outline NotePathItem. The app and test harness read SearchableNotes through the editor seam.