### PR TITLE
refactor(clipboard): make structural cut remove nodes immediately — u…

### DIFF
--- a/docs/legacy-backlog.md
+++ b/docs/legacy-backlog.md
@@ -495,10 +495,6 @@ Follow-ups to the spec in [docs/specs/outliner/body.md](specs/outliner/body.md):
   V2 history only persists structure, not the caret). This is global, not
   body-specific — RemDo's undo tests assert structure only. Decide if restoring
   selection on undo is worth wiring the Yjs `UndoManager` StackItem `meta`.
-- Pasting a pending structural cut into a *non-cut* note's body is currently a
-  no-op (cut stays pending) since a body can't hold notes. Pin the final
-  semantics (no-op vs. move-as-flattened-text) in the cut/paste redesign;
-  `ClipboardPlugin` `SELECTION_INSERT_CLIPBOARD_NODES_COMMAND` body branch.
 
 ## Docs spec accuracy (branch docs/spec-accuracy)
 

--- a/docs/specs/outliner/body.md
+++ b/docs/specs/outliner/body.md
@@ -38,6 +38,16 @@ For commands that act on a note, a caret or inline text selection inside a body
 targets its owning editor note. For example,
 [indent](./indentation.md#indent) targets the whole note, not the body text alone.
 
+## Clipboard
+
+- Pasting into a body edits that body without structurally replacing its owning
+  note.
+- A single copied or cut note contributes its rich inline label content; its
+  body and sub-notes are not inserted.
+- Multiple copied or cut notes contribute their line-separated plain-text
+  clipboard representation.
+- Note structure is never inserted into a body.
+
 ## Navigation
 
 Within a body, keys behave as follows:

--- a/docs/specs/outliner/clipboard.md
+++ b/docs/specs/outliner/clipboard.md
@@ -17,9 +17,6 @@ note-link identity across clipboard and persistence boundaries.
 - Internal structural copy data omits note identity. Cut data records its source
   document identity and retains note identity. [Note IDs](./note-ids.md#clipboard)
   owns how paste resolves those identities before the common insertion path.
-- The first valid same-document cut paste at the unchanged deletion focus
-  restores the recorded source gap exactly. After focus moves, normal
-  [Insertion](./insertion.md) placement applies.
 - Pasting while a [selected note range](./selection.md#note-ranges) is active
   replaces that selection with the pasted notes.
 - Clipboard data can be pasted repeatedly. RemDo does not keep a pending cut or

--- a/docs/specs/outliner/clipboard.md
+++ b/docs/specs/outliner/clipboard.md
@@ -6,27 +6,28 @@ note-link identity across clipboard and persistence boundaries.
 
 ## Structural selection
 
-- Copy duplicates the selected notes (including their
-  [subtrees](./note-model.md#definitions) and each note's [body](./body.md)) and leaves the document unchanged.
-- Copy captures the notes as they are at copy time; later edits to the
-  originals do not change what gets pasted.
-- Cut creates a **pending cut** from the
-  [selected note range](./selection.md#note-ranges). Its notes stay in place until paste moves them.
-- Any edit inside the pending cut before pasting, including a remote edit,
-  cancels the cut so edits stay where they were made.
-- After creating a pending cut, the caret moves to the start of the range's
-  first note in [document order](./note-model.md#definitions).
+- Copy and cut capture the selected notes (including their
+  [subtrees](./note-model.md#definitions) and each note's [body](./body.md)) as
+  they are at the time of the operation. Later source edits do not change the
+  clipboard data.
+- Copy leaves the document unchanged.
+- Cut removes the [selected note range](./selection.md#note-ranges)
+  immediately. Focus follows the [structural deletion](./deletion.md#structural-selection)
+  order.
+- Internal structural copy data omits note identity. Cut data records its source
+  document identity and retains note identity. [Note IDs](./note-ids.md#clipboard)
+  owns how paste resolves those identities before the common insertion path.
+- The first valid same-document cut paste at the unchanged deletion focus
+  restores the recorded source gap exactly. After focus moves, normal
+  [Insertion](./insertion.md) placement applies.
 - Pasting while a [selected note range](./selection.md#note-ranges) is active
   replaces that selection with the pasted notes.
-- Pasting a pending cut moves its notes to the new location. If the cut is no
-  longer valid, paste does nothing.
-- A pending cut can be pasted once; after a successful paste it is cleared.
-- If you try to paste inside the pending cut, nothing happens and the cut
-  remains pending.
-- Starting a new copy/cut, or pasting unrelated content, cancels the pending cut.
-- Pasting a copied note **outside** RemDo (plain text) includes each note's own
-  text, then its body text on the following line(s), then its sub-notes — the
-  order the note reads on screen.
+- Clipboard data can be pasted repeatedly. RemDo does not keep a pending cut or
+  wait for a paste before removing cut notes.
+- Pasting into a note body follows the [Body clipboard contract](./body.md#clipboard).
+- Copying or cutting notes supplies plain text for pasting **outside** RemDo:
+  each note's own text, then its body text on the following line(s), then its
+  sub-notes — the order the note reads on screen.
 
 ## Inline text selection (single note)
 
@@ -41,4 +42,6 @@ note-link identity across clipboard and persistence boundaries.
 - Pasting notes or multi-line plain text inserts multiple notes (one line per
   note for plain text).
 - Placement follows the caret-position rules from [Insertion](./insertion.md).
+- When the document's only note is empty, pasting notes replaces that empty
+  note instead of leaving it beside the pasted notes.
 - After a multi-note paste, focus lands at the end of the last inserted note.

--- a/docs/specs/outliner/note-ids.md
+++ b/docs/specs/outliner/note-ids.md
@@ -49,9 +49,25 @@ within a document; a global `noteRef` combines document and note identity.
 
 ### Clipboard
 
-Cut/paste moves preserve existing `noteId` values for the moved notes.
+Internal structural copy data omits `noteId` values. Cut data retains them and
+records its source `documentId`. Paste resolves the identity of the whole
+incoming note set before insertion:
 
-Behavioral clipboard rules (placement, move validation, focus) live in [Clipboard](./clipboard.md).
+1. Copy follows normal note creation, which assigns fresh `noteId` values to
+   every pasted note.
+2. Cut preserves every incoming `noteId` only when the source and destination
+   are the same document and none of the incoming IDs exists in the destination.
+3. Any collision, cross-document cut, or other structural clipboard data has
+   all incoming note IDs removed before insertion and follows the same normal
+   note creation path as copy.
+
+The decision uses no pending source-editor state. Consequently, the first
+same-document structural paste after a cut can preserve identity; after those
+IDs exist again, later structural pastes of the same clipboard data create new
+identities.
+
+Behavioral clipboard rules (capture, removal, placement, and focus) live in
+[Clipboard](./clipboard.md).
 
 ### Merge and deletion
 
@@ -84,7 +100,10 @@ Behavioral clipboard rules (placement, move validation, focus) live in [Clipboar
 - `noteId` generation must be collision-resistant across clients; IDs are
   created locally and synced as part of the note content.
 - Remote operations must not overwrite existing `noteId` values during normal application.
-- [Pending-cut cancellation](./clipboard.md#structural-selection) under remote edits is defined by Clipboard.
+- A [structural cut](./clipboard.md#structural-selection) syncs as an ordinary
+  immediate deletion. Remote edits do not cancel or alter its clipboard snapshot.
+- Paste resolves identity against the destination state at the time it is
+  applied; IDs introduced or restored by remote operations count as collisions.
 
 ## Global references
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -143,14 +143,6 @@ short topic headings. Remove rejected or obsolete items and empty sections.
   The symmetric offset-0 case and end-of-inline as the note's last child are
   already handled.
 
-- **Hold `ClipboardPlugin` structural refactor.** At 996 lines it is the
-  editor's largest module and an obvious split candidate, but its cut and paste
-  semantics are due to change: pasting a pending structural cut into a body is
-  an interim no-op whose final behavior is still
-  [undecided](legacy-backlog.md#note-body-follow-ups). Splitting it
-  first would restructure code around behavior that is about to move, so the
-  split follows the cut/paste decision.
-
 - **Duplicate note-splitting helper.** `$splitContentItemAtSelection` exists in
   both `InsertionPlugin.tsx` and `ClipboardPlugin.tsx`. Only the insertion copy
   resolves the anchor through inline ancestors, so pasting with the caret inside

--- a/src/client/editor/editing/clipboard/ClipboardPlugin.tsx
+++ b/src/client/editor/editing/clipboard/ClipboardPlugin.tsx
@@ -1,86 +1,89 @@
 import { $createListItemNode, $isListItemNode, $isListNode } from '@lexical/list';
 import type { ListItemNode, ListNode } from '@lexical/list';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
-import type { BaseSelection, EditorState, LexicalEditor, LexicalNode, NodeKey, RangeSelection, SerializedLexicalNode } from 'lexical';
+import type { BaseSelection, LexicalEditor, LexicalNode, RangeSelection, SerializedLexicalNode } from 'lexical';
 import { $getHtmlContent, $getLexicalContent, setLexicalClipboardDataTransfer } from '@lexical/clipboard';
 import type { LexicalClipboardData } from '@lexical/clipboard';
 import {
+  $addUpdateTag,
   $copyNode,
   $createTextNode,
-  $getNodeByKey,
   $getSelection,
   $insertNodes,
   $isElementNode,
   $isRangeSelection,
+  $isRootNode,
   $isTextNode,
   $setState,
   COMMAND_PRIORITY_CRITICAL,
   COMMAND_PRIORITY_LOW,
   COPY_COMMAND,
+  CUT_TAG,
   CUT_COMMAND,
+  PASTE_TAG,
   PASTE_COMMAND,
   SELECTION_INSERT_CLIPBOARD_NODES_COMMAND,
 } from 'lexical';
 import { useEffect, useRef } from 'react';
 import { mergeRegister } from '@lexical/utils';
-import { createUniqueNoteId, createNoteIdAvoiding } from '#domain/notes/ids';
+import { createUniqueNoteId } from '#domain/notes/ids';
 import { $createNoteLinkNode } from '#client/editor/features/links/note-link-node';
-import { noteIdState } from '#client/editor/runtime/note-ids/note-id-state';
-import { isSerializedBodyWrapper } from '#client/editor/runtime/serialized-note-types';
+import { $getNoteId, noteIdState } from '#client/editor/runtime/note-ids/note-id-state';
 import {
   $getOrCreateChildList,
   getBodyWrapper,
   getContentSiblings,
+  getNodesForNote,
+  getPreviousContentSibling,
   insertBefore,
   isContentItem,
-  flattenNoteNodes,
 } from '#client/editor/outline/list-structure';
-import { getNoteBody, $getSelectionBody, $resolveNoteForSelectionPoint } from '#client/editor/outline/selection/body-region';
+import { getNoteBody, $getSelectionBody } from '#client/editor/outline/selection/body-region';
 import { getNoteOwnText } from '#client/editor/outline/selection/note-body';
 import { resolveContentItemFromNode } from '#client/editor/outline/schema';
 import { getViewRoot } from '#client/editor/outline/view-root';
-import { $selectItemEdge } from '#client/editor/outline/selection/caret';
+import { $selectItemEdge, isPointAtBoundary } from '#client/editor/outline/selection/caret';
 import { resolveCaretPlacement } from '#client/editor/outline/selection/caret-placement';
 import { $resolveStructuralDeletionHeads } from '#client/editor/outline/selection/deletion';
 import type { OutlineSelectionRange } from '#client/editor/outline/selection/model';
-import { $collectStructuralItemKeysFromRange } from '#client/editor/outline/selection/range';
 import {
   $resolveStructuralRangeFromLexicalSelection,
   $resolveStructuralRangeFromOutlineSelection,
 } from '#client/editor/outline/selection/structural-range';
-import type { StructuralOverlayConfig } from '#client/editor/outline/selection/overlay';
-import { updateStructuralOverlay } from '#client/editor/outline/selection/overlay';
 import {
   getFirstDescendantListItem,
   getNestedList,
   getNextContentSibling,
+  getParentContentItem,
+  getSubtreeTail,
   noteHasChildren,
   removeNoteHeads,
 } from '#client/editor/outline/selection/tree';
-import { COLLAPSE_STRUCTURAL_SELECTION_COMMAND } from '#client/editor/foundation/commands';
 import { parseOwnedNoteLinkUrl } from '#client/editor/features/links/note-link-url';
 import { $findNoteById } from '#client/editor/outline/note-traversal';
 import { useCollaborationStatus } from '#client/editor/runtime/collaboration';
 import { $autoExpandIfFolded } from '#client/editor/outline/fold-state';
+import { $deleteNotesInRange } from '#client/editor/outline/selection/delete-selection';
 
 const NEWLINE_PATTERN = /\r?\n/;
 
-interface CutMarker {
-  markedKeys: Set<string>;
-  range: OutlineSelectionRange;
+type ClipboardOperation = 'copy' | 'cut';
+
+interface RemDoClipboardSourceGap {
+  kind: 'before' | 'after' | 'first-child';
+  noteId: string;
+}
+
+interface RemDoClipboardProvenance {
+  sourceDocumentId: string;
+  sourceGap?: RemDoClipboardSourceGap;
 }
 
 interface ClipboardPayload {
   namespace: string;
   nodes: SerializedLexicalNode[];
-  remdoCut?: boolean;
+  remdo?: RemDoClipboardProvenance;
 }
-
-const CUT_MARKER_OVERLAY: StructuralOverlayConfig = {
-  className: 'editor-input--cut-marker',
-  topVar: '--cut-marker-top',
-  heightVar: '--cut-marker-height',
-};
 
 function isClipboardEvent(event: ClipboardEvent | KeyboardEvent | InputEvent | null): event is ClipboardEvent {
   return !!event && 'clipboardData' in event;
@@ -101,69 +104,17 @@ function getClipboardPayload(event: ClipboardEvent | KeyboardEvent | InputEvent 
   }
 }
 
-function $getContentKeyFromNode(node: LexicalNode | null): string | null {
-  // A node inside a body belongs to its owner note, so a dirty key under a cut
-  // note's body maps back to that note — editing the body invalidates the cut.
-  return $resolveNoteForSelectionPoint(node)?.getKey() ?? null;
-}
-
-function $getContentKeyFromNodeKey(key: string): string | null {
-  return $getContentKeyFromNode($getNodeByKey(key));
-}
-
-function hasMarkedDirtyKey(marker: CutMarker, keys: NodeKey[], state: EditorState): boolean {
-  if (keys.length === 0) {
-    return false;
+function getClipboardProvenance(payload: ClipboardPayload | null): RemDoClipboardProvenance | null {
+  const provenance = payload?.remdo;
+  if (
+    !provenance ||
+    typeof provenance.sourceDocumentId !== 'string'
+  ) {
+    return null;
   }
-
-  return state.read(() => {
-    for (const key of keys) {
-      const contentKey = $getContentKeyFromNodeKey(key);
-      if (contentKey && marker.markedKeys.has(contentKey)) {
-        return true;
-      }
-    }
-
-    return false;
-  });
+  return provenance;
 }
 
-function hasBoundaryDirtyKey(marker: CutMarker, keys: NodeKey[], state: EditorState): boolean {
-  if (keys.length === 0) {
-    return false;
-  }
-
-  return state.read(() => {
-    const boundaryKeys = $collectStructuralItemKeysFromRange(marker.range);
-    if (boundaryKeys.size === 0) {
-      return false;
-    }
-
-    for (const key of keys) {
-      const contentKey = $getContentKeyFromNodeKey(key);
-      if (contentKey && boundaryKeys.has(contentKey)) {
-        return true;
-      }
-    }
-
-    return false;
-  });
-}
-
-function $isCaretWithinMarkedSelection(marker: CutMarker, selection: BaseSelection | null): boolean {
-  if (!$isRangeSelection(selection) || !selection.isCollapsed()) {
-    return false;
-  }
-
-  // A caret inside a cut note's body is still inside the cut boundary (the body
-  // travels with the note), so resolve body points to their owner note.
-  const contentItem = $resolveNoteForSelectionPoint(selection.anchor.getNode());
-  if (!contentItem) {
-    return false;
-  }
-
-  return marker.markedKeys.has(contentItem.getKey());
-}
 function $createNoteItemWithText(text: string): ListItemNode {
   const item = $createListItemNode();
   item.append($createTextNode(text));
@@ -197,6 +148,21 @@ function $cloneClipboardNodeTree<T extends LexicalNode>(node: T): T {
   return clone;
 }
 
+function $extractSingleNoteLabelNodes(nodes: LexicalNode[]): LexicalNode[] | null {
+  const contentItems = $extractClipboardListChildren(nodes).filter(isContentItem);
+  if (contentItems.length !== 1) {
+    return null;
+  }
+
+  // A structural payload can place the note's body-wrapper beside the content
+  // item and its subtree list inside it. A body is an inline destination, so
+  // only the note label's rich inline children belong there.
+  return contentItems[0]!
+    .getChildren()
+    .filter((child) => !$isListNode(child))
+    .map($cloneClipboardNodeTree);
+}
+
 function $extractInlineClipboardNodes(nodes: LexicalNode[]): LexicalNode[] {
   const items = $extractClipboardListChildren(nodes);
   if (items.length === 1) {
@@ -221,11 +187,19 @@ function $extractInlineClipboardNodes(nodes: LexicalNode[]): LexicalNode[] {
   return [];
 }
 
-// Insert clipboard nodes into a note body (rich text). Inline content (a single
-// copied note's children, or already-inline nodes) keeps its rich nodes — note
-// links, date tokens, formatting — via `$insertNodes`. A structural/multi-note
+// Insert clipboard nodes into a note body (rich text). A single copied note's
+// rich inline label, or already-inline nodes, keeps note links, date tokens,
+// and formatting via `$insertNodes`. A structural/multi-note
 // payload cannot live in a body as structure, so it flattens to plain text.
 function $insertClipboardNodesIntoBody(selection: RangeSelection, nodes: LexicalNode[]): void {
+  const singleNoteLabelNodes = $extractSingleNoteLabelNodes(nodes);
+  if (singleNoteLabelNodes !== null) {
+    if (singleNoteLabelNodes.length > 0) {
+      $insertNodes(singleNoteLabelNodes);
+    }
+    return;
+  }
+
   const inlineNodes = $extractInlineClipboardNodes(nodes);
   if (inlineNodes.length > 0) {
     $insertNodes(inlineNodes);
@@ -345,7 +319,7 @@ function $insertFirstChildNotes(contentItem: ListItemNode | null, lines: string[
   }
 }
 
-function $regenerateClipboardNoteIds(nodes: LexicalNode[], reservedIds: Set<string>) {
+function $clearClipboardNoteIds(nodes: LexicalNode[]) {
   const stack = nodes.toReversed();
   while (stack.length > 0) {
     const node = stack.pop();
@@ -354,9 +328,7 @@ function $regenerateClipboardNoteIds(nodes: LexicalNode[], reservedIds: Set<stri
     }
 
     if (isContentItem(node)) {
-      const next = createNoteIdAvoiding(reservedIds);
-      $setState(node, noteIdState, next);
-      reservedIds.add(next);
+      $setState(node, noteIdState, undefined);
     }
 
     if ($isElementNode(node)) {
@@ -369,6 +341,51 @@ function $regenerateClipboardNoteIds(nodes: LexicalNode[], reservedIds: Set<stri
       }
     }
   }
+}
+
+function $canPreserveClipboardNoteIds(
+  nodes: LexicalNode[],
+  provenance: RemDoClipboardProvenance | null,
+  currentDocumentId: string
+): boolean {
+  if (
+    !provenance ||
+    currentDocumentId.length === 0 ||
+    provenance.sourceDocumentId !== currentDocumentId
+  ) {
+    return false;
+  }
+
+  const seenIds = new Set<string>();
+  let noteCount = 0;
+  const stack = nodes.toReversed();
+  while (stack.length > 0) {
+    const node = stack.pop();
+    if (!node) {
+      continue;
+    }
+
+    if (isContentItem(node)) {
+      noteCount += 1;
+      const noteId = $getNoteId(node);
+      if (!noteId || noteId === currentDocumentId || seenIds.has(noteId) || $findNoteById(noteId)) {
+        return false;
+      }
+      seenIds.add(noteId);
+    }
+
+    if ($isElementNode(node)) {
+      const children = node.getChildren();
+      for (let i = children.length - 1; i >= 0; i -= 1) {
+        const child = children[i];
+        if (child) {
+          stack.push(child);
+        }
+      }
+    }
+  }
+
+  return noteCount > 0;
 }
 
 function $insertInternalLinkFromPlainText(
@@ -441,61 +458,27 @@ function serializeNodeTree(node: LexicalNode): SerializedLexicalNode {
 
 type SerializedElement = SerializedLexicalNode & { noteId?: string; children?: SerializedLexicalNode[] };
 
-// Splice each note's body-wrapper into Lexical's serialized clipboard nodes,
-// right after the note's content list item, so a copied note carries its body.
-// Lexical's serialization already produces the correct content shape (inline for
-// a bare note, list-wrapped when structural) but omits the body-wrapper, which is
-// not part of the selection's node span; this adds it from the live note. Walks
-// the whole tree so a sub-note's body (in a nested children list) is carried too.
-function $injectNoteBodiesIntoClipboardNodes(nodes: SerializedLexicalNode[]): void {
-  for (let i = nodes.length - 1; i >= 0; i -= 1) {
-    const node = nodes[i] as SerializedElement;
-    if (Array.isArray(node.children)) {
-      $injectNoteBodiesIntoClipboardNodes(node.children);
+function clearSerializedNoteIds(nodes: SerializedLexicalNode[]): void {
+  for (const node of nodes) {
+    const element = node as SerializedElement;
+    if (element.type === 'listitem') {
+      delete element.noteId;
     }
-    if (node.type !== 'listitem' || typeof node.noteId !== 'string') {
-      continue;
-    }
-    const note = $findNoteById(node.noteId);
-    const body = note ? getBodyWrapper(note) : null;
-    if (!body) {
-      continue;
-    }
-    // Always carry the full live body. Lexical may already have serialized a
-    // body-wrapper here — either the complete one (between two selected notes) or
-    // a partial one when a note range ends mid-body — so replace any
-    // existing serialized body-wrapper rather than appending a second.
-    if (isSerializedBodyWrapper(nodes[i + 1])) {
-      nodes.splice(i + 1, 1, serializeNodeTree(body));
-    } else {
-      nodes.splice(i + 1, 0, serializeNodeTree(body));
+    if (Array.isArray(element.children)) {
+      clearSerializedNoteIds(element.children);
     }
   }
 }
 
-// Replace each serialized note's own (inline) content with the live note's full
-// own content, leaving any nested children list untouched. A structural copy is
-// whole-note, but Lexical serializes the partial text under the selection's
-// boundary heads; this restores the complete label (text, note links, dates) so
-// an internal paste recreates the whole note. Recurses into nested lists.
-function $restoreFullNoteContentInClipboardNodes(nodes: SerializedLexicalNode[]): void {
-  for (const node of nodes) {
-    const element = node as SerializedElement;
-    if (element.type === 'listitem' && typeof element.noteId === 'string' && Array.isArray(element.children)) {
-      const note = $findNoteById(element.noteId);
-      if (note) {
-        // A content note's direct children are its own inline content (text,
-        // note links, dates); its sub-notes live in a sibling children-wrapper,
-        // which Lexical serializes as a nested `list` child here — keep that.
-        const ownContent = note.getChildren().map(serializeNodeTree);
-        const nestedList = element.children.filter((child) => child.type === 'list');
-        element.children = [...ownContent, ...nestedList];
-      }
-    }
-    if (Array.isArray(element.children)) {
-      $restoreFullNoteContentInClipboardNodes(element.children);
-    }
+function $serializeStructuralHeads(heads: ListItemNode[]): SerializedLexicalNode[] | null {
+  const parentList = heads[0]?.getParent();
+  if (!$isListNode(parentList)) {
+    return null;
   }
+
+  const list = parentList.exportJSON() as SerializedElement;
+  list.children = heads.flatMap((head) => getNodesForNote(head).map(serializeNodeTree));
+  return [list];
 }
 
 // The plain-text line(s) a note contributes: its own text, then its body's text.
@@ -514,18 +497,45 @@ function noteClipboardPlainText(note: ListItemNode): string[] {
   return lines;
 }
 
+function $captureClipboardSourceGap(heads: ListItemNode[]): RemDoClipboardSourceGap | null {
+  const firstHead = heads[0];
+  const lastHead = heads.at(-1);
+  if (!firstHead || !lastHead) {
+    return null;
+  }
+
+  const parentNote = getParentContentItem(firstHead);
+  const previousSibling = getPreviousContentSibling(firstHead);
+  const nextSibling = getNextContentSibling(lastHead);
+  const anchor = nextSibling ?? previousSibling ?? parentNote;
+  if (!anchor) {
+    return null;
+  }
+
+  const noteId = $getNoteId(anchor);
+  if (!noteId) {
+    return null;
+  }
+
+  return {
+    kind: nextSibling ? 'before' : previousSibling ? 'after' : 'first-child',
+    noteId,
+  };
+}
+
 // Whole-note clipboard population (copy/cut). A note's body and sub-notes are
-// content it owns, so they travel with it. Reuse Lexical's serialization for the
-// content/links/structure and inject the body-wrappers it omits; build the plain
-// text as each note's own text followed by its body text. `isCut` tags the
-// payload so a same-document cut-paste can move the originals. Returns false for
+// content it owns, so they travel with it. Reuse Lexical's clipboard envelope
+// and serialize the resolved semantic note heads directly, including their
+// bodies and subtrees. RemDo provenance identifies same-document cuts without
+// keeping live source nodes or mutable clipboard state. Returns false for
 // caret and inline selections, leaving inline copy to Lexical's default handler.
 function $populateClipboardFromSelection(
   editor: LexicalEditor,
   heads: ListItemNode[],
   selection: BaseSelection | null,
   event: ClipboardEvent | KeyboardEvent | null,
-  isCut: boolean
+  operation: ClipboardOperation,
+  sourceDocumentId: string
 ): boolean {
   if (!isClipboardEvent(event) || !event.clipboardData || heads.length === 0) {
     return false;
@@ -541,14 +551,23 @@ function $populateClipboardFromSelection(
   } catch {
     return false;
   }
-  $injectNoteBodiesIntoClipboardNodes(payload.nodes);
-  // A note range acts on whole notes, but the native RangeSelection may
-  // only partially cover a head's label (a drag from mid-label into its body),
-  // so Lexical serializes a truncated label. Restore each note's full own content
-  // from the live tree, matching the plain-text flavor.
-  $restoreFullNoteContentInClipboardNodes(payload.nodes);
-  if (isCut) {
-    payload.remdoCut = true;
+  const structuralNodes = $serializeStructuralHeads(heads);
+  if (!structuralNodes) {
+    return false;
+  }
+  payload.nodes = structuralNodes;
+  if (operation === 'cut') {
+    const sourceGap = $captureClipboardSourceGap(heads);
+    payload.remdo = {
+      sourceDocumentId,
+      ...(sourceGap ? { sourceGap } : {}),
+    };
+  } else {
+    // IDs help assemble a complete snapshot above, but copied notes represent
+    // new content rather than existing identity. Keep the final payload free of
+    // note identity so normal note creation owns ID initialization on paste.
+    clearSerializedNoteIds(payload.nodes);
+    delete payload.remdo;
   }
 
   const data: LexicalClipboardData = {
@@ -583,11 +602,69 @@ function $resolveStructuralClipboardContext(
   return heads.length === 0 ? null : { selection, selectionRange, heads };
 }
 
+function $isSoleEmptyRootNote(item: ListItemNode, parentList: ListNode): boolean {
+  return (
+    $isRootNode(parentList.getParent()) &&
+    getContentSiblings(parentList).length === 1 &&
+    getNoteOwnText(item).length === 0 &&
+    getBodyWrapper(item) === null &&
+    !noteHasChildren(item)
+  );
+}
+
+function $resolveClipboardSourceGap(
+  selection: BaseSelection | null,
+  sourceGap: RemDoClipboardSourceGap | undefined
+): { parentList: ListNode; nextSibling: ListItemNode | null } | null {
+  if (
+    !$isRangeSelection(selection) ||
+    !selection.isCollapsed() ||
+    !sourceGap ||
+    typeof sourceGap.noteId !== 'string'
+  ) {
+    return null;
+  }
+
+  const anchor = $findNoteById(sourceGap.noteId);
+  if (!anchor) {
+    return null;
+  }
+
+  const focusItem = resolveContentItemFromNode(selection.anchor.getNode());
+  if (sourceGap.kind === 'first-child') {
+    if (focusItem !== anchor || !isPointAtBoundary(selection.anchor, anchor, 'end')) {
+      return null;
+    }
+    $autoExpandIfFolded(anchor);
+    const parentList = $getOrCreateChildList(anchor);
+    return { parentList, nextSibling: getFirstDescendantListItem(parentList) };
+  }
+
+  const parentList = anchor.getParent();
+  if (!$isListNode(parentList)) {
+    return null;
+  }
+
+  if (sourceGap.kind === 'before') {
+    if (focusItem !== anchor || !isPointAtBoundary(selection.anchor, anchor, 'start')) {
+      return null;
+    }
+    return { parentList, nextSibling: anchor };
+  }
+
+  const previousTail = getSubtreeTail(anchor);
+  if (focusItem !== previousTail || !isPointAtBoundary(selection.anchor, previousTail, 'end')) {
+    return null;
+  }
+  return { parentList, nextSibling: getNextContentSibling(anchor) };
+}
+
 function $insertNodesAtSelection(
   editor: LexicalEditor,
   structuralRange: OutlineSelectionRange | null,
   selection: BaseSelection | null,
-  nodes: LexicalNode[]
+  nodes: LexicalNode[],
+  sourceGap?: RemDoClipboardSourceGap
 ): boolean {
   if (nodes.length === 0) {
     return false;
@@ -597,7 +674,11 @@ function $insertNodesAtSelection(
   let parentList: ListNode | null = null;
   let nextSibling: LexicalNode | null = null;
 
-  if (structuralRange) {
+  const resolvedSourceGap = $resolveClipboardSourceGap(selection, sourceGap);
+  if (resolvedSourceGap) {
+    parentList = resolvedSourceGap.parentList;
+    nextSibling = resolvedSourceGap.nextSibling;
+  } else if (structuralRange) {
     orderedHeads = $resolveStructuralDeletionHeads(structuralRange, selection);
     if (orderedHeads.length === 0) {
       return false;
@@ -630,44 +711,52 @@ function $insertNodesAtSelection(
       return false;
     }
     parentList = candidateParent;
-    const placement = resolveCaretPlacement(selection, contentItem);
-    if (!placement) {
-      return false;
-    }
-    const viewRootKey = getViewRoot(editor);
-    const isViewRoot = viewRootKey !== null && contentItem.getKey() === viewRootKey;
-
-    if (placement === 'start') {
-      if (isViewRoot) {
-        $autoExpandIfFolded(contentItem);
-        parentList = $getOrCreateChildList(contentItem);
-        nextSibling = getFirstDescendantListItem(parentList);
-      } else {
-        nextSibling = contentItem;
-      }
-    } else if (placement === 'middle') {
-      if (isViewRoot) {
-        $autoExpandIfFolded(contentItem);
-        parentList = $getOrCreateChildList(contentItem);
-        const split = $splitContentItemAtSelection(contentItem, selection, 'first-child');
-        nextSibling = split ?? getFirstDescendantListItem(parentList);
-      } else {
-        const split = $splitContentItemAtSelection(contentItem, selection);
-        nextSibling = split ? contentItem : getNextContentSibling(contentItem);
-      }
+    if ($isSoleEmptyRootNote(contentItem, parentList)) {
+      // Structural deletion keeps the document editable by creating one empty
+      // root note. Pasting notes into an otherwise empty document replaces that
+      // placeholder instead of leaving an extra blank note behind.
+      orderedHeads = [contentItem];
+      nextSibling = getNextContentSibling(contentItem);
     } else {
-      if (isViewRoot) {
-        $autoExpandIfFolded(contentItem);
-        parentList = $getOrCreateChildList(contentItem);
-        nextSibling = getFirstDescendantListItem(parentList);
-      } else {
-        const nested = getNestedList(contentItem);
-        if (nested && noteHasChildren(contentItem)) {
+      const placement = resolveCaretPlacement(selection, contentItem);
+      if (!placement) {
+        return false;
+      }
+      const viewRootKey = getViewRoot(editor);
+      const isViewRoot = viewRootKey !== null && contentItem.getKey() === viewRootKey;
+
+      if (placement === 'start') {
+        if (isViewRoot) {
           $autoExpandIfFolded(contentItem);
-          parentList = nested;
-          nextSibling = getFirstDescendantListItem(nested);
+          parentList = $getOrCreateChildList(contentItem);
+          nextSibling = getFirstDescendantListItem(parentList);
         } else {
-          nextSibling = getNextContentSibling(contentItem);
+          nextSibling = contentItem;
+        }
+      } else if (placement === 'middle') {
+        if (isViewRoot) {
+          $autoExpandIfFolded(contentItem);
+          parentList = $getOrCreateChildList(contentItem);
+          const split = $splitContentItemAtSelection(contentItem, selection, 'first-child');
+          nextSibling = split ?? getFirstDescendantListItem(parentList);
+        } else {
+          const split = $splitContentItemAtSelection(contentItem, selection);
+          nextSibling = split ? contentItem : getNextContentSibling(contentItem);
+        }
+      } else {
+        if (isViewRoot) {
+          $autoExpandIfFolded(contentItem);
+          parentList = $getOrCreateChildList(contentItem);
+          nextSibling = getFirstDescendantListItem(parentList);
+        } else {
+          const nested = getNestedList(contentItem);
+          if (nested && noteHasChildren(contentItem)) {
+            $autoExpandIfFolded(contentItem);
+            parentList = nested;
+            nextSibling = getFirstDescendantListItem(nested);
+          } else {
+            nextSibling = getNextContentSibling(contentItem);
+          }
         }
       }
     }
@@ -702,52 +791,15 @@ function $insertNodesAtSelection(
 }
 export function ClipboardPlugin() {
   const [editor] = useLexicalComposerContext();
-  const { docEpoch, docId } = useCollaborationStatus();
+  const { docId } = useCollaborationStatus();
   const lastPasteSelectionRangeRef = useRef<OutlineSelectionRange | null>(null);
-  const cutMarkerRef = useRef<CutMarker | null>(null);
-  const lastPasteWasCutRef = useRef(false);
+  const lastPasteProvenanceRef = useRef<RemDoClipboardProvenance | null>(null);
 
   useEffect(() => {
-    const setCutMarker = (next: CutMarker | null) => {
-      cutMarkerRef.current = next;
-      updateStructuralOverlay(editor, next?.range ?? null, next !== null, CUT_MARKER_OVERLAY);
-    };
-
     return mergeRegister(
-      editor.registerUpdateListener(({ dirtyElements, dirtyLeaves, editorState, prevEditorState }) => {
-        const marker = cutMarkerRef.current;
-        if (!marker) {
-          return;
-        }
-
-        const dirtyKeys: NodeKey[] = [];
-        for (const key of dirtyElements.keys()) {
-          dirtyKeys.push(key);
-        }
-        for (const key of dirtyLeaves) {
-          dirtyKeys.push(key);
-        }
-
-        // dirty keys are empty for selection-only updates with no content changes.
-        if (
-          dirtyKeys.length > 0 &&
-          (
-            hasMarkedDirtyKey(marker, dirtyKeys, editorState) ||
-            hasMarkedDirtyKey(marker, dirtyKeys, prevEditorState) ||
-            hasBoundaryDirtyKey(marker, dirtyKeys, editorState) ||
-            hasBoundaryDirtyKey(marker, dirtyKeys, prevEditorState)
-          )
-        ) {
-          setCutMarker(null);
-          return;
-        }
-
-        updateStructuralOverlay(editor, marker.range, true, CUT_MARKER_OVERLAY);
-      }),
       editor.registerCommand(
         COPY_COMMAND,
         (event) => {
-          setCutMarker(null);
           // For a whole-note (structural) selection, build the clipboard from the
           // selected notes so each note carries its body and sub-notes. Inline
           // selections fall through to Lexical's default text/rich-text copy.
@@ -755,29 +807,41 @@ export function ClipboardPlugin() {
           if (!context) {
             return false;
           }
-          return $populateClipboardFromSelection(editor, context.heads, context.selection, event, false);
+          return $populateClipboardFromSelection(
+            editor,
+            context.heads,
+            context.selection,
+            event,
+            'copy',
+            docId
+          );
         },
         COMMAND_PRIORITY_CRITICAL
       ),
       editor.registerCommand(
         CUT_COMMAND,
         (event) => {
-          // Runs inside Lexical's command update context. Populate the clipboard,
-          // then collapse in the same update so the committed selection (and the
-          // outline-selection snapshot derived from it) is observed atomically.
+          // Runs inside Lexical's command update context. Capture the selected
+          // whole notes before deleting them through the semantic outline owner.
           const context = $resolveStructuralClipboardContext(editor);
           if (!context) {
             return false;
           }
 
-          const marker: CutMarker = {
-            markedKeys: $collectStructuralItemKeysFromRange(context.selectionRange),
-            range: context.selectionRange,
-          };
-          $populateClipboardFromSelection(editor, context.heads, context.selection, event, true);
-          setCutMarker(marker);
-          editor.dispatchCommand(COLLAPSE_STRUCTURAL_SELECTION_COMMAND, { edge: 'start' });
-          return true;
+          const populated = $populateClipboardFromSelection(
+            editor,
+            context.heads,
+            context.selection,
+            event,
+            'cut',
+            docId
+          );
+          if (!populated) {
+            return false;
+          }
+
+          $addUpdateTag(CUT_TAG);
+          return $deleteNotesInRange(editor, context.selectionRange);
         },
         COMMAND_PRIORITY_CRITICAL
       ),
@@ -788,8 +852,8 @@ export function ClipboardPlugin() {
             return false;
           }
 
-          const wasCutPaste = lastPasteWasCutRef.current;
-          lastPasteWasCutRef.current = false;
+          const provenance = lastPasteProvenanceRef.current;
+          lastPasteProvenanceRef.current = null;
 
           // A selection inside a body is rich text, not outline structure, so a
           // paste there inserts the clipboard's plain text (never list nodes,
@@ -798,18 +862,12 @@ export function ClipboardPlugin() {
             ? $getSelectionBody(payload.selection)
             : null;
 
-          // For a non-cut paste the body insert is unconditional; a cut-paste
-          // must first honor the cut no-op rule below (pasting inside the cut
-          // boundary does nothing and leaves the cut pending), so it is handled
-          // within the wasCutPaste block.
-          if (pasteBody && !wasCutPaste && $isRangeSelection(payload.selection)) {
-            setCutMarker(null);
+          if (pasteBody && $isRangeSelection(payload.selection)) {
             lastPasteSelectionRangeRef.current = null;
             $insertClipboardNodesIntoBody(payload.selection, payload.nodes);
             return true;
           }
 
-          const marker = cutMarkerRef.current;
           const outlineSelection = editor.selection.get();
           const isInlineSelection =
             outlineSelection?.kind !== 'structural' && $isInlineSelectionWithinSingleNote(payload.selection);
@@ -821,54 +879,6 @@ export function ClipboardPlugin() {
           // The cached range has now been consumed; clear it so it can't leak
           // into the next paste, regardless of which exit path below runs.
           lastPasteSelectionRangeRef.current = null;
-
-          if (wasCutPaste) {
-            if (!marker) {
-              return true;
-            }
-
-            const caretInMarked =
-              selectionRange === null && $isCaretWithinMarkedSelection(marker, payload.selection);
-            const selectedMarkedKeys =
-              selectionRange === null
-                ? null
-                : $collectStructuralItemKeysFromRange(selectionRange);
-            const intersection =
-              caretInMarked ||
-              (selectedMarkedKeys !== null && [...selectedMarkedKeys].some((key) => marker.markedKeys.has(key)));
-            if (intersection) {
-              return true;
-            }
-
-            // A body is rich text and cannot structurally hold the cut notes, so
-            // there is no valid move target here. Interim behavior: no-op, leave
-            // the cut pending (never inject list nodes into the body, and never
-            // copy-without-moving). Final semantics are deferred to the cut/paste
-            // redesign — see
-            // docs/legacy-backlog.md#note-body-follow-ups.
-            if (pasteBody) {
-              return true;
-            }
-
-            const ordered = $resolveStructuralDeletionHeads(marker.range, payload.selection);
-            if (ordered.length > 0) {
-              const nodesToMove = flattenNoteNodes(ordered);
-              let insertionRange = selectionRange;
-              let insertionSelection: BaseSelection | null = payload.selection;
-              if (isInlineSelection && $isRangeSelection(insertionSelection) && !insertionSelection.isCollapsed()) {
-                insertionSelection.insertText('');
-                insertionSelection = $getSelection();
-                insertionRange = null;
-              }
-              setCutMarker(null);
-              if ($insertNodesAtSelection(editor, insertionRange, insertionSelection, nodesToMove)) {
-                return true;
-              }
-            }
-
-            setCutMarker(null);
-            return true;
-          }
 
           if (isInlineSelection && $isRangeSelection(payload.selection)) {
             const inlineContentItem = resolveContentItemFromNode(payload.selection.anchor.getNode());
@@ -892,13 +902,26 @@ export function ClipboardPlugin() {
             return true;
           }
 
-          const reservedIds = new Set<string>();
-          if (docId.length > 0) {
-            reservedIds.add(docId);
+          const isSameDocumentCut = (
+            provenance !== null
+            && docId.length > 0
+            && provenance.sourceDocumentId === docId
+          );
+          const canPreserveNoteIds = $canPreserveClipboardNoteIds(payload.nodes, provenance, docId);
+          if (!canPreserveNoteIds) {
+            // Copy, foreign/legacy payloads, cross-document cuts, and colliding
+            // cuts all create notes. Erase any supplied identity and let the
+            // ordinary ListItemNode transform initialize IDs after insertion.
+            $clearClipboardNoteIds(payload.nodes);
           }
-          $regenerateClipboardNoteIds(payload.nodes, reservedIds);
           const insertNodes = $extractClipboardListChildren(payload.nodes);
-          return $insertNodesAtSelection(editor, selectionRange, payload.selection, insertNodes);
+          return $insertNodesAtSelection(
+            editor,
+            selectionRange,
+            payload.selection,
+            insertNodes,
+            isSameDocumentCut ? provenance.sourceGap : undefined
+          );
         },
         COMMAND_PRIORITY_LOW
       ),
@@ -909,10 +932,7 @@ export function ClipboardPlugin() {
           const outlineRange = $resolveStructuralRangeFromOutlineSelection(outlineSelection);
           lastPasteSelectionRangeRef.current = outlineRange ? { ...outlineRange } : null;
           const clipboardPayload = getClipboardPayload(event);
-          lastPasteWasCutRef.current = clipboardPayload?.remdoCut === true;
-          if (!lastPasteWasCutRef.current) {
-            setCutMarker(null);
-          }
+          lastPasteProvenanceRef.current = getClipboardProvenance(clipboardPayload);
           if (clipboardPayload) {
             return false;
           }
@@ -933,9 +953,10 @@ export function ClipboardPlugin() {
               plainText,
               currentOrigin,
               docId,
-                outlineSelection?.kind ?? null
+              outlineSelection?.kind ?? null
             );
             if (handled) {
+              $addUpdateTag(PASTE_TAG);
               lastPasteSelectionRangeRef.current = null;
               event.preventDefault();
               return true;
@@ -953,6 +974,7 @@ export function ClipboardPlugin() {
           // newlines into LineBreakNodes (the body's line representation that line
           // nav relies on), not literal "\n" inside a text node.
           if ($isRangeSelection(selection) && $getSelectionBody(selection)) {
+            $addUpdateTag(PASTE_TAG);
             lastPasteSelectionRangeRef.current = null;
             selection.insertRawText(plainText);
             event.preventDefault();
@@ -983,6 +1005,7 @@ export function ClipboardPlugin() {
             handled = $insertNodesAtSelection(editor, selectionRange, selection, nodes);
           }
           if (handled) {
+            $addUpdateTag(PASTE_TAG);
             lastPasteSelectionRangeRef.current = null;
           }
 
@@ -995,7 +1018,7 @@ export function ClipboardPlugin() {
         COMMAND_PRIORITY_CRITICAL
       )
     );
-  }, [editor, docEpoch, docId]);
+  }, [editor, docId]);
 
   return null;
 }

--- a/src/client/editor/editing/clipboard/clipboard-note-ids.spec.ts
+++ b/src/client/editor/editing/clipboard/clipboard-note-ids.spec.ts
@@ -1,5 +1,6 @@
+import { $createListItemNode } from '@lexical/list';
 import { describe, expect, it } from 'vitest';
-import { $isLineBreakNode } from 'lexical';
+import { $createTextNode, $isLineBreakNode, $isTextNode, $setState, UNDO_COMMAND } from 'lexical';
 import { waitFor } from '@testing-library/react';
 
 import type { SerializedLexicalNode, SerializedTextNode } from 'lexical';
@@ -31,6 +32,9 @@ import {
 import { createUniqueNoteId } from '#domain/notes/ids';
 import { $findNoteById } from '#client/editor/outline/note-traversal';
 import { getNoteBody } from '#client/editor/outline/selection/body-region';
+import { $getOrCreateChildList } from '#client/editor/outline/list-structure';
+import { $addNoteBody } from '#client/editor/features/note-body/note-body-ops';
+import { noteIdState } from '#client/editor/runtime/note-ids/note-id-state';
 import { renderRemdoEditor } from '#tests-collab/render-editor';
 
 function findSerializedListItem(node: SerializedLexicalNode, noteId: string): SerializedNoteListItemNode | null {
@@ -54,6 +58,12 @@ function findSerializedNoteLinkInNodes(nodes: SerializedLexicalNode[] | undefine
 function collectSerializedNoteLinksInNodes(nodes: SerializedLexicalNode[] | undefined): SerializedNoteLinkNode[] {
   return collectSerializedNodes(nodes, (candidate): candidate is SerializedNoteLinkNode => (
     candidate.type === 'note-link'
+  ));
+}
+
+function collectSerializedListItems(nodes: SerializedLexicalNode[] | undefined): SerializedLexicalNode[] {
+  return collectSerializedNodes(nodes, (candidate): candidate is SerializedLexicalNode => (
+    candidate.type === 'listitem'
   ));
 }
 
@@ -94,6 +104,11 @@ describe('note ids on paste', () => {
   it('assigns a fresh noteId when pasting a copied note', meta({ fixture: 'flat' }), async ({ remdo }) => {
     await selectStructuralNotes(remdo, 'note2');
     const clipboardPayload = await copySelection(remdo);
+    expect((clipboardPayload as { remdo?: unknown }).remdo).toBeUndefined();
+    expect(
+      collectSerializedListItems(clipboardPayload.nodes as SerializedLexicalNode[])
+        .every((item) => !('noteId' in item))
+    ).toBe(true);
     await placeCaretAtNote(remdo, 'note3', Number.POSITIVE_INFINITY);
 
     await pastePayload(remdo, clipboardPayload);
@@ -184,6 +199,50 @@ describe('note ids on paste', () => {
     expect(links.filter((link) => link.noteId === 'note2')).toHaveLength(2);
   });
 
+  it('pastes only one structural note label into a body and preserves its formatting', meta({ fixture: 'formatted' }), async ({ remdo }) => {
+    await remdo.mutate(() => {
+      const source = $findNoteById('mixedFormatting')!;
+      $addNoteBody(source).append($createTextNode('owned body'));
+
+      const child = $createListItemNode();
+      child.append($createTextNode('owned child'));
+      $setState(child, noteIdState, 'ownedChild');
+      $getOrCreateChildList(source).append(child);
+
+      const destination = $findNoteById('underline')!;
+      $addNoteBody(destination).append($createTextNode('destination '));
+    });
+
+    await selectNoteRange(remdo, 'mixedFormatting', 'ownedChild');
+    await waitFor(() => {
+      expect(remdo.editor.selection.isStructural()).toBe(true);
+    });
+    const clipboardPayload = await copySelection(remdo);
+    expect(
+      collectSerializedListItems(clipboardPayload.nodes as SerializedLexicalNode[])
+        .every((item) => !('noteId' in item))
+    ).toBe(true);
+
+    await remdo.mutate(() => {
+      getNoteBody($findNoteById('underline')!)!.selectEnd();
+    });
+    await pastePayload(remdo, clipboardPayload);
+
+    const destinationBody = remdo.editor.getEditorState().read(() => {
+      const body = getNoteBody($findNoteById('underline')!)!;
+      return {
+        text: body.getTextContent(),
+        hasBoldLabelText: body.getChildren().some(
+          (child) => $isTextNode(child) && child.getTextContent() === 'bold ' && child.hasFormat('bold')
+        ),
+      };
+    });
+    expect(destinationBody).toEqual({
+      text: 'destination plain bold italic underline plain',
+      hasBoldLabelText: true,
+    });
+  });
+
   it('pasting a multi-note payload into a body uses line breaks, not literal newlines', meta({ fixture: 'flat' }), async ({ remdo }) => {
     // A multi-note structural payload can't live in a body as structure, so it
     // flattens to text — but the body's line representation is LineBreakNodes,
@@ -204,6 +263,11 @@ describe('note ids on paste', () => {
       return body.getChildren().filter($isLineBreakNode).length;
     });
     expect(lineBreaks).toBeGreaterThan(0);
+    expect(remdo).toMatchOutline([
+      { noteId: 'note1', text: 'note1' },
+      { noteId: 'note2', text: 'note2' },
+      { noteId: 'note3', text: 'note3', body: 'note1\nnote2' },
+    ]);
   });
 
   it('materializes same-document note-link docId in clipboard payload', meta({ fixture: 'flat' }), async ({ remdo }) => {
@@ -230,48 +294,40 @@ describe('note ids on paste', () => {
     expect(pastedLink.docId).toBe(remdo.getCollabDocId());
   });
 
-  it('materializes explicit docId for every note link in structural cut clipboard payloads', meta({ fixture: 'links' }), async ({ remdo }) => {
-    await selectStructuralNotes(remdo, 'note1');
-    const cutPayload = (await cutSelection(remdo)) as { remdoCut?: boolean; nodes?: SerializedLexicalNode[] };
-    expect(cutPayload.remdoCut).toBe(true);
-
-    const links = collectSerializedNoteLinksInNodes(cutPayload.nodes);
-    const sameDocLink = links.find((link) => link.noteId === 'note2')!;
-    const crossDocLink = links.find((link) => link.noteId === 'remoteNote')!;
-
-    expect(sameDocLink.docId).toBe(remdo.getCollabDocId());
-    expect(crossDocLink.docId).toBe('otherDoc');
-  });
-
   it(
-    'preserves the source docId when same-document note links are pasted into another document',
+    'regenerates noteIds for a cross-document cut while preserving source link targets',
     meta({ fixture: 'links' }),
     async ({ remdo }) => {
-      // The `links` fixture includes a same-document note link in note1 -> note2.
-      await selectStructuralNotes(remdo, 'note1');
-      const clipboardPayload = await copySelection(remdo);
       const sourceDocId = remdo.getCollabDocId();
-      const copiedClipboardLink = findSerializedNoteLinkInNodes(clipboardPayload.nodes as SerializedLexicalNode[])!;
-      expect(copiedClipboardLink.noteId).toBe('note2');
-      // Clipboard payload must still carry explicit docId so links remain self-contained across browser boundaries.
-      expect(copiedClipboardLink.docId).toBe(sourceDocId);
+      await selectStructuralNotes(remdo, 'note1');
+      const clipboardPayload = (await cutSelection(remdo)) as { nodes?: SerializedLexicalNode[] };
+
+      expect(flattenOutline(readOutline(remdo)).some((note) => note.noteId === 'note1')).toBe(false);
+
+      const clipboardLinks = collectSerializedNoteLinksInNodes(clipboardPayload.nodes);
+      const sameDocClipboardLink = clipboardLinks.find((link) => link.noteId === 'note2')!;
+      const crossDocClipboardLink = clipboardLinks.find((link) => link.noteId === 'remoteNote')!;
+      expect(sameDocClipboardLink.docId).toBe(sourceDocId);
+      expect(crossDocClipboardLink.docId).toBe('otherDoc');
 
       const destinationDocId = createUniqueNoteId();
 
       const { api: destination, unmount } = await renderRemdoEditor(destinationDocId);
       try {
-        // Cross-browser paste has no shared runtime between editors; destination can only rely on clipboard payload.
         const insertionNoteId = readOutline(destination).at(-1)!.noteId!;
         await placeCaretAtNote(destination, insertionNoteId, Number.POSITIVE_INFINITY);
         await pastePayload(destination, clipboardPayload);
 
-        // Pasting at end of the last root note inserts the new note as the new last root note in this fixture.
         const pastedNoteId = readOutline(destination).at(-1)!.noteId!;
+        expect(pastedNoteId).not.toBe('note1');
+
         const rootListNode = getSerializedRootListNode(destination) as SerializedLexicalNode;
         const pastedListItem = findSerializedListItem(rootListNode, pastedNoteId)!;
-        const pastedLink = findSerializedNoteLink(pastedListItem)!;
-        expect(pastedLink.noteId).toBe('note2');
-        expect(pastedLink.docId).toBe(sourceDocId);
+        const pastedLinks = collectSerializedNoteLinksInNodes([pastedListItem]);
+        const sameDocPastedLink = pastedLinks.find((link) => link.noteId === 'note2')!;
+        const crossDocPastedLink = pastedLinks.find((link) => link.noteId === 'remoteNote')!;
+        expect(sameDocPastedLink.docId).toBe(sourceDocId);
+        expect(crossDocPastedLink.docId).toBe('otherDoc');
       } finally {
         unmount();
       }
@@ -477,48 +533,125 @@ describe('note ids on paste', () => {
     expect(outline[1]?.noteId).not.toBe('note2');
   });
 
-  it('marks structural cut clipboard payloads as cut', meta({ fixture: 'flat' }), async ({ remdo }) => {
-    await selectStructuralNotes(remdo, 'note2');
-    const payload = (await cutSelection(remdo)) as { remdoCut?: boolean };
-    expect(payload.remdoCut).toBe(true);
-  });
-
   it('keeps inline text cuts within a single note', meta({ fixture: 'flat' }), async ({ remdo }) => {
     const note2Text = getNoteTextNode(remdo, 'note2');
     await dragDomSelectionBetween(note2Text, 0, note2Text, 2);
 
-    const payload = (await cutSelection(remdo)) as { remdoCut?: boolean };
-    expect(payload.remdoCut).not.toBe(true);
+    await cutSelection(remdo);
 
     const outline = readOutline(remdo);
     expect(outline).toHaveLength(3);
     expect(outline[1]?.text).toBe('te2');
   });
 
-  it('preserves noteIds when cutting and pasting back in place', meta({ fixture: 'flat' }), async ({ remdo }) => {
+  it('pastes a structural cut into a body as inline content', meta({ fixture: 'flat' }), async ({ remdo }) => {
+    await placeCaretAtNote(remdo, 'note1', Number.POSITIVE_INFINITY);
+    await pressKey(remdo, { key: 'Enter', shift: true });
+    await typeText(remdo, 'body ');
+
     await selectStructuralNotes(remdo, 'note2');
     const clipboardPayload = await cutSelection(remdo);
-    expect(remdo).toMatchSelection({ state: 'caret', note: 'note2' });
+    expect(flattenOutline(readOutline(remdo)).some((note) => note.noteId === 'note2')).toBe(false);
 
-    expect(remdo).toMatchOutline([
-      { noteId: 'note1', text: 'note1' },
-      { noteId: 'note2', text: 'note2' },
-      { noteId: 'note3', text: 'note3' },
-    ]);
-
-    await placeCaretAtNote(remdo, 'note2', Number.POSITIVE_INFINITY);
+    await remdo.mutate(() => {
+      getNoteBody($findNoteById('note1')!)!.selectEnd();
+    });
     await pastePayload(remdo, clipboardPayload);
 
     expect(remdo).toMatchOutline([
-      { noteId: 'note1', text: 'note1' },
-      { noteId: 'note2', text: 'note2' },
+      { noteId: 'note1', text: 'note1', body: 'body note2' },
       { noteId: 'note3', text: 'note3' },
     ]);
+  });
+
+  it('removes a structural range immediately and round-trips the same gap exactly', meta({ fixture: 'flat' }), async ({ remdo }) => {
+    await remdo.waitForSynced();
+    const initialState = remdo.getEditorState();
+
+    await selectNoteRange(remdo, 'note1', 'note2');
+    await waitFor(() => {
+      expect(remdo).toMatchSelection({ state: 'structural', notes: ['note1', 'note2'] });
+    });
+
+    const clipboardPayload = await cutSelection(remdo);
+
+    expect(remdo).toMatchOutline([
+      { noteId: 'note3', text: 'note3' },
+    ]);
+    expect(remdo).toMatchSelection({ state: 'caret', note: 'note3' });
+
+    await pastePayload(remdo, clipboardPayload);
+    await remdo.waitForSynced();
+    expect(remdo).toMatchEditorState(initialState);
+  });
+
+  it('round-trips a sole child at its original parent gap', meta({ fixture: 'tree' }), async ({ remdo }) => {
+    await remdo.waitForSynced();
+    const initialState = remdo.getEditorState();
+
+    await selectStructuralNotes(remdo, 'note3');
+    const clipboardPayload = await cutSelection(remdo);
+
+    expect(remdo).toMatchOutline([
+      { noteId: 'note1', text: 'note1' },
+      { noteId: 'note2', text: 'note2' },
+    ]);
+    expect(remdo).toMatchSelection({ state: 'caret', note: 'note2' });
+
+    await pastePayload(remdo, clipboardPayload);
+    await remdo.waitForSynced();
+
+    expect(remdo).toMatchEditorState(initialState);
+  });
+
+  it('round-trips a tail sibling after the previous sibling subtree', meta({ fixture: 'tree-complex' }), async ({ remdo }) => {
+    await remdo.waitForSynced();
+    const initialState = remdo.getEditorState();
+
+    await selectStructuralNotes(remdo, 'note4');
+    const clipboardPayload = await cutSelection(remdo);
+
+    expect(flattenOutline(readOutline(remdo)).some((note) => note.noteId === 'note4')).toBe(false);
+    expect(remdo).toMatchSelection({ state: 'caret', note: 'note3' });
+
+    await pastePayload(remdo, clipboardPayload);
+    await remdo.waitForSynced();
+
+    expect(remdo).toMatchEditorState(initialState);
+  });
+
+  it('round-trips formatted note content exactly', meta({ fixture: 'formatted' }), async ({ remdo }) => {
+    const initialState = remdo.getEditorState();
+
+    await selectStructuralNotes(remdo, 'mixedFormatting');
+    const clipboardPayload = await cutSelection(remdo);
+    expect(flattenOutline(readOutline(remdo)).some((note) => note.noteId === 'mixedFormatting')).toBe(false);
+
+    await pastePayload(remdo, clipboardPayload);
+
+    expect(remdo).toMatchEditorState(initialState);
+  });
+
+  it('replaces the empty document placeholder when every note is cut and pasted back', meta({ fixture: 'flat' }), async ({ remdo }) => {
+    const initialState = remdo.getEditorState();
+
+    await selectNoteRange(remdo, 'note1', 'note3');
+    await waitFor(() => {
+      expect(remdo).toMatchSelection({ state: 'structural', notes: ['note1', 'note2', 'note3'] });
+    });
+    const clipboardPayload = await cutSelection(remdo);
+    expect(remdo).toMatchOutline([{ noteId: null }]);
+
+    await pastePayload(remdo, clipboardPayload);
+
+    expect(remdo).toMatchEditorState(initialState);
   });
 
   it('inserts multi-note cuts at a caret inside note text without replacing surrounding text', meta({ fixture: 'flat' }), async ({ remdo }) => {
     await selectStructuralNotes(remdo, 'note2', 'note3');
     const clipboardPayload = await cutSelection(remdo);
+
+    expect(remdo).toMatchOutline([{ noteId: 'note1', text: 'note1' }]);
 
     await placeCaretAtNote(remdo, 'note1', 1);
 
@@ -533,321 +666,186 @@ describe('note ids on paste', () => {
     ]);
   });
 
-  it('preserves noteIds when cutting and pasting a note elsewhere', meta({ fixture: 'flat' }), async ({ remdo }) => {
-    await selectStructuralNotes(remdo, 'note2');
-    const clipboardPayload = await cutSelection(remdo);
-
-    expect(remdo).toMatchOutline([
-      { noteId: 'note1', text: 'note1' },
-      { noteId: 'note2', text: 'note2' },
-      { noteId: 'note3', text: 'note3' },
-    ]);
-
-    await placeCaretAtNote(remdo, 'note3', Number.POSITIVE_INFINITY);
-    await pastePayload(remdo, clipboardPayload);
-
-    expect(remdo).toMatchOutline([
-      { noteId: 'note1', text: 'note1' },
-      { noteId: 'note3', text: 'note3' },
-      { noteId: 'note2', text: 'note2' },
-    ]);
-  });
-
-  it('clears cut markers after a copy', meta({ fixture: 'flat' }), async ({ remdo }) => {
-    await selectStructuralNotes(remdo, 'note2');
-    const cutPayload = await cutSelection(remdo);
-
-    await selectStructuralNotes(remdo, 'note1');
-    await copySelection(remdo);
-
-    const expectedOutline = readOutline(remdo);
-
-    // Paste uses the old cut payload instead of the new paste on purpose; with the marker cleared, it should be a no-op.
-    await placeCaretAtNote(remdo, 'note3', Number.POSITIVE_INFINITY);
-    await pastePayload(remdo, cutPayload);
-
-    expect(remdo).toMatchOutline(expectedOutline);
-  });
-
-  it('replaces the cut marker with the most recent cut', meta({ fixture: 'flat' }), async ({ remdo }) => {
-    //cut 1
-    await selectStructuralNotes(remdo, 'note2');
-    await cutSelection(remdo);
-    //cut 2
-    await selectStructuralNotes(remdo, 'note1');
-    const cutPayload = await cutSelection(remdo);
-
-    await placeCaretAtNote(remdo, 'note3', Number.POSITIVE_INFINITY);
-
-    //paste cut 2
-    await pastePayload(remdo, cutPayload);
-
-    expect(remdo).toMatchOutline([
-      { noteId: 'note2', text: 'note2' },
-      { noteId: 'note3', text: 'note3' },
-      { noteId: 'note1', text: 'note1' },
-    ]);
-  });
-
-  it('clears cut markers after pasting a non-cut payload', meta({ fixture: 'flat' }), async ({ remdo }) => {
-    await selectStructuralNotes(remdo, 'note2');
-    const cutPayload = await cutSelection(remdo);
-    await selectStructuralNotes(remdo, 'note1');
-    const copyPayload = await copySelection(remdo);
-
-    await placeCaretAtNote(remdo, 'note3', Number.POSITIVE_INFINITY);
-    await pastePayload(remdo, copyPayload);
-
-    const expectedOutline = readOutline(remdo);
-
-    await placeCaretAtNote(remdo, 'note2', Number.POSITIVE_INFINITY);
-    await pastePayload(remdo, cutPayload);
-
-    expect(remdo).toMatchOutline(expectedOutline);
-  });
-
-  it('collapses the note range after cutting multiple notes', meta({ fixture: 'flat' }), async ({ remdo }) => {
-    await selectStructuralNotes(remdo, 'note2', 'note3');
-    expect(remdo).toMatchSelection({ state: 'structural', notes: ['note2', 'note3'] });
-
-    await cutSelection(remdo);
-
-    expect(remdo).toMatchSelection({ state: 'caret', note: 'note2' });
-  });
-
-  it('collapses multi-note inline selection after cut to the visual start', meta({ fixture: 'flat' }), async ({ remdo }) => {
-    await selectNoteRange(remdo, 'note3', 'note2');
-    await waitFor(() => {
-      expect(remdo).toMatchSelection({ state: 'structural', notes: ['note2', 'note3'] });
-    });
-
-    await cutSelection(remdo);
-
-    expect(remdo).toMatchSelection({ state: 'caret', note: 'note2' });
-  });
-
-  it('drops cut markers after local edits', meta({ fixture: 'flat' }), async ({ remdo }) => {
-    await selectStructuralNotes(remdo, 'note2');
-    const clipboardPayload = await cutSelection(remdo);
-
-    await placeCaretAtNote(remdo, 'note2', Number.POSITIVE_INFINITY);
-    await typeText(remdo, ' edited');
-
-    await placeCaretAtNote(remdo, 'note3', Number.POSITIVE_INFINITY);
-    await pastePayload(remdo, clipboardPayload);
-
-    expect(remdo).toMatchOutline([
-      { noteId: 'note1', text: 'note1' },
-      { noteId: 'note2', text: 'note2 edited' },
-      { noteId: 'note3', text: 'note3' },
-    ]);
-  });
-
-  it('pasting inside a cut note\'s own body is a no-op and leaves the cut pending', meta({ fixture: 'flat' }), async ({ remdo }) => {
-    // Cut note2 (with a body), then paste with the caret inside note2's body.
-    // The body is inside the cut boundary, so per docs/specs/outliner/clipboard.md the
-    // paste does nothing and the cut stays pending — no text is inserted into the
-    // body and the note is not duplicated.
-    await placeCaretAtNote(remdo, 'note2', Number.POSITIVE_INFINITY);
-    await pressKey(remdo, { key: 'Enter', shift: true });
-    await typeText(remdo, 'body');
-
-    await selectStructuralNotes(remdo, 'note2');
-    const clipboardPayload = await cutSelection(remdo);
-
-    // Caret inside note2's own body, then paste the cut.
-    await remdo.mutate(() => {
-      getNoteBody($findNoteById('note2')!)!.selectEnd();
-    });
-    await pastePayload(remdo, clipboardPayload);
-
-    // No-op: note2 unchanged (body not duplicated), nothing moved.
-    expect(remdo).toMatchOutline([
-      { noteId: 'note1', text: 'note1' },
-      { noteId: 'note2', text: 'note2', body: 'body' },
-      { noteId: 'note3', text: 'note3' },
-    ]);
-
-    // The cut is still pending: pasting elsewhere now moves note2.
-    await placeCaretAtNote(remdo, 'note3', Number.POSITIVE_INFINITY);
-    await pastePayload(remdo, clipboardPayload);
-    expect(remdo).toMatchOutline([
-      { noteId: 'note1', text: 'note1' },
-      { noteId: 'note3', text: 'note3' },
-      { noteId: 'note2', text: 'note2', body: 'body' },
-    ]);
-  });
-
-  it('pasting a cut into a non-cut note\'s body is an interim no-op (cut stays pending)', meta({ fixture: 'flat' }), async ({ remdo }) => {
-    // A body can't structurally hold notes, so there is no valid move target.
-    // Interim behavior (final semantics deferred to the cut/paste redesign, see
-    // docs/legacy-backlog.md#note-body-follow-ups): the paste does nothing and
-    // the cut stays pending — it must never inject list nodes into the body nor
-    // copy the text without moving.
-    await placeCaretAtNote(remdo, 'note1', Number.POSITIVE_INFINITY);
-    await pressKey(remdo, { key: 'Enter', shift: true });
-    await typeText(remdo, 'b1');
-
-    await selectStructuralNotes(remdo, 'note2');
-    const clipboardPayload = await cutSelection(remdo);
-
-    // Caret inside note1's body (note1 is NOT cut), then paste the cut.
-    await remdo.mutate(() => {
-      getNoteBody($findNoteById('note1')!)!.selectEnd();
-    });
-    await pastePayload(remdo, clipboardPayload);
-
-    // No-op: note1's body unchanged, note2 still in place.
-    expect(remdo).toMatchOutline([
-      { noteId: 'note1', text: 'note1', body: 'b1' },
-      { noteId: 'note2', text: 'note2' },
-      { noteId: 'note3', text: 'note3' },
-    ]);
-
-    // Cut still pending: pasting elsewhere completes the move.
-    await placeCaretAtNote(remdo, 'note3', Number.POSITIVE_INFINITY);
-    await pastePayload(remdo, clipboardPayload);
-    expect(remdo).toMatchOutline([
-      { noteId: 'note1', text: 'note1', body: 'b1' },
-      { noteId: 'note3', text: 'note3' },
-      { noteId: 'note2', text: 'note2' },
-    ]);
-  });
-
-  it('drops cut markers after editing a cut note\'s body', meta({ fixture: 'flat' }), async ({ remdo }) => {
-    // Give note2 a body, cut it, then edit inside the body. The body is part of
-    // the cut note, so the edit must cancel the pending cut — a later paste does
-    // not move the (now-edited) note.
-    await placeCaretAtNote(remdo, 'note2', Number.POSITIVE_INFINITY);
-    await pressKey(remdo, { key: 'Enter', shift: true });
-    await typeText(remdo, 'body');
-
-    await selectStructuralNotes(remdo, 'note2');
-    const clipboardPayload = await cutSelection(remdo);
-
-    // Edit inside note2's body.
-    await remdo.mutate(() => {
-      getNoteBody($findNoteById('note2')!)!.selectEnd();
-    });
-    await typeText(remdo, ' more');
-
-    await placeCaretAtNote(remdo, 'note3', Number.POSITIVE_INFINITY);
-    await pastePayload(remdo, clipboardPayload);
-
-    expect(remdo).toMatchOutline([
-      { noteId: 'note1', text: 'note1' },
-      { noteId: 'note2', text: 'note2', body: 'body more' },
-      { noteId: 'note3', text: 'note3' },
-    ]);
-  });
-
-  it('drops cut markers after local deletions', meta({ fixture: 'flat' }), async ({ remdo }) => {
-    await selectStructuralNotes(remdo, 'note2');
-    const clipboardPayload = await cutSelection(remdo);
-
-    await placeCaretAtNote(remdo, 'note2', 0);
-    await pressKey(remdo, { key: 'Backspace' });
-
-    const expectedOutline = [
-      { noteId: 'note1', text: 'note1 note2' },
-      { noteId: 'note3', text: 'note3' },
-    ];
-    await waitFor(() => {
-      expect(remdo).toMatchOutline(expectedOutline);
-    });
-
-    await placeCaretAtNote(remdo, 'note3', Number.POSITIVE_INFINITY);
-    await pastePayload(remdo, clipboardPayload);
-
-    expect(remdo).toMatchOutline(expectedOutline);
-  });
-
-  it('drops cut markers after structural edits', meta({ fixture: 'flat' }), async ({ remdo }) => {
-    await selectStructuralNotes(remdo, 'note2');
-    const clipboardPayload = await cutSelection(remdo);
-
-    await placeCaretAtNote(remdo, 'note2', 0);
-    await pressKey(remdo, { key: 'Tab' });
-
-    await placeCaretAtNote(remdo, 'note3', Number.POSITIVE_INFINITY);
-
-    const expectedOutline = readOutline(remdo);
-
-    await pastePayload(remdo, clipboardPayload);
-
-    expect(remdo).toMatchOutline(expectedOutline);
-  });
-
-  it('drops cut markers after inserts inside the cut boundary', meta({ fixture: 'flat' }), async ({ remdo }) => {
-    await selectStructuralNotes(remdo, 'note2', 'note3');
-    const clipboardPayload = await cutSelection(remdo);
-
-    await placeCaretAtNote(remdo, 'note2', Number.POSITIVE_INFINITY);
-    await pressKey(remdo, { key: 'Enter' });
-
-    const expectedOutline = readOutline(remdo);
-
-    await placeCaretAtNote(remdo, 'note1', 0);
-    await pastePayload(remdo, clipboardPayload);
-
-    expect(remdo).toMatchOutline(expectedOutline);
-  });
-
-  it('treats structural pastes inside a cut subtree as a no-op', meta({ fixture: 'flat' }), async ({ remdo }) => {
-    await selectStructuralNotes(remdo, 'note2');
-    const clipboardPayload = await cutSelection(remdo);
-
-    const expectedOutline = readOutline(remdo);
-
-    await selectStructuralNotes(remdo, 'note2');
-    await pastePayload(remdo, clipboardPayload);
-
-    expect(remdo).toMatchOutline(expectedOutline);
-
-    await placeCaretAtNote(remdo, 'note3', Number.POSITIVE_INFINITY);
-    await pastePayload(remdo, clipboardPayload);
-
-    expect(remdo).toMatchOutline([
-      { noteId: 'note1', text: 'note1' },
-      { noteId: 'note3', text: 'note3' },
-      { noteId: 'note2', text: 'note2' },
-    ]);
-  });
-
-  it('treats caret paste inside a cut subtree as a no-op', meta({ fixture: 'flat' }), async ({ remdo }) => {
-    await selectStructuralNotes(remdo, 'note2');
-    const clipboardPayload = await cutSelection(remdo);
-
-    const expectedOutline = readOutline(remdo);
-
-    await placeCaretAtNote(remdo, 'note2', Number.POSITIVE_INFINITY);
-    await pastePayload(remdo, clipboardPayload);
-
-    expect(remdo).toMatchOutline(expectedOutline);
-
-    await placeCaretAtNote(remdo, 'note3', Number.POSITIVE_INFINITY);
-    await pastePayload(remdo, clipboardPayload);
-
-    expect(remdo).toMatchOutline([
-      { noteId: 'note1', text: 'note1' },
-      { noteId: 'note3', text: 'note3' },
-      { noteId: 'note2', text: 'note2' },
-    ]);
-  });
-
-  it('treats a second paste after cut as a no-op', meta({ fixture: 'flat' }), async ({ remdo }) => {
-    await selectStructuralNotes(remdo, 'note2');
-    const clipboardPayload = await cutSelection(remdo);
-
-    await placeCaretAtNote(remdo, 'note3', Number.POSITIVE_INFINITY);
-    await pastePayload(remdo, clipboardPayload);
-
-    const expectedOutline = readOutline(remdo);
+  it('moves a subtree away and back with exact editor-state round-trip', meta({ fixture: 'tree-complex' }), async ({ remdo }) => {
+    const initialState = remdo.getEditorState();
+
+    await selectStructuralNotes(remdo, 'note6', 'note7');
+    const firstCutPayload = await cutSelection(remdo);
+    expect(flattenOutline(readOutline(remdo)).some((note) => note.noteId === 'note6' || note.noteId === 'note7')).toBe(false);
 
     await placeCaretAtNote(remdo, 'note1', Number.POSITIVE_INFINITY);
+    await pastePayload(remdo, firstCutPayload);
+
+    expect(remdo).toMatchOutline([
+      {
+        noteId: 'note1',
+        text: 'note1',
+        children: [
+          { noteId: 'note6', text: 'note6', children: [{ noteId: 'note7', text: 'note7' }] },
+          { noteId: 'note2', text: 'note2', children: [{ noteId: 'note3', text: 'note3' }] },
+          { noteId: 'note4', text: 'note4' },
+        ],
+      },
+      { noteId: 'note5', text: 'note5' },
+    ]);
+
+    await selectStructuralNotes(remdo, 'note6', 'note7');
+    const secondCutPayload = await cutSelection(remdo);
+    expect(flattenOutline(readOutline(remdo)).some((note) => note.noteId === 'note6' || note.noteId === 'note7')).toBe(false);
+
+    await placeCaretAtNote(remdo, 'note5', Number.POSITIVE_INFINITY);
+    await pastePayload(remdo, secondCutPayload);
+
+    expect(remdo).toMatchEditorState(initialState);
+  });
+
+  it('regenerates colliding cut ids after undo restores the source', meta({ fixture: 'flat' }), async ({ remdo }) => {
+    await remdo.waitForSynced();
+    const initialState = remdo.getEditorState();
+
+    await selectStructuralNotes(remdo, 'note2');
+    const clipboardPayload = await cutSelection(remdo);
+    expect(flattenOutline(readOutline(remdo)).some((note) => note.noteId === 'note2')).toBe(false);
+
+    await remdo.dispatchCommand(UNDO_COMMAND);
+    await remdo.waitForSynced();
+    expect(remdo).toMatchEditorState(initialState);
+
+    await placeCaretAtNote(remdo, 'note3', Number.POSITIVE_INFINITY);
+    await pastePayload(remdo, clipboardPayload);
+
+    expect(remdo).toMatchOutline([
+      { noteId: 'note1', text: 'note1' },
+      { noteId: 'note2', text: 'note2' },
+      { noteId: 'note3', text: 'note3' },
+      { noteId: null, text: 'note2' },
+    ]);
+
+    const outline = readOutline(remdo);
+    const pastedId = outline.at(-1)?.noteId;
+    expect(pastedId).toEqual(expect.any(String));
+    expect(pastedId).not.toBe('note2');
+    const noteIds = collectOutlineNoteIds(outline);
+    expect(new Set(noteIds).size).toBe(noteIds.length);
+  });
+
+  it('restores a cut source gap even when a collision regenerates its id', meta({ fixture: 'tree-complex' }), async ({ remdo }) => {
+    await selectStructuralNotes(remdo, 'note4');
+    const clipboardPayload = await cutSelection(remdo);
+
+    await remdo.mutate(() => {
+      const collision = $createListItemNode();
+      collision.append($createTextNode('collision'));
+      $setState(collision, noteIdState, 'note4');
+      $getOrCreateChildList($findNoteById('note5')!).append(collision);
+    });
+    await pastePayload(remdo, clipboardPayload);
+
+    expect(remdo).toMatchOutline([
+      {
+        noteId: 'note1',
+        text: 'note1',
+        children: [
+          { noteId: 'note2', text: 'note2', children: [{ noteId: 'note3', text: 'note3' }] },
+          { noteId: null, text: 'note4' },
+        ],
+      },
+      { noteId: 'note5', text: 'note5', children: [{ noteId: 'note4', text: 'collision' }] },
+      { noteId: 'note6', text: 'note6', children: [{ noteId: 'note7', text: 'note7' }] },
+    ]);
+
+    const restoredId = findOutlineNodeByText(readOutline(remdo), 'note4')!.noteId;
+    expect(restoredId).toEqual(expect.any(String));
+    expect(restoredId).not.toBe('note4');
+  });
+
+  it('regenerates a same-document cut id that equals the document id', meta({ fixture: 'flat' }), async ({ remdo }) => {
+    await selectStructuralNotes(remdo, 'note2');
+    const clipboardPayload = (await cutSelection(remdo)) as { nodes: SerializedLexicalNode[] };
+    const pastedNote = findSerializedListItem(clipboardPayload.nodes[0]!, 'note2')!;
+    pastedNote.noteId = remdo.getCollabDocId();
 
     await pastePayload(remdo, clipboardPayload);
 
-    expect(remdo).toMatchOutline(expectedOutline);
+    const outline = readOutline(remdo);
+    const restoredNote = findOutlineNodeByText(outline, 'note2')!;
+    expect(restoredNote.noteId).toEqual(expect.any(String));
+    expect(restoredNote.noteId).not.toBe(remdo.getCollabDocId());
+    const noteIds = collectOutlineNoteIds(outline);
+    expect(new Set(noteIds).size).toBe(noteIds.length);
+  });
+
+  it('regenerates every id in a same-document cut payload containing duplicates', meta({ fixture: 'flat' }), async ({ remdo }) => {
+    await selectStructuralNotes(remdo, 'note1', 'note2');
+    const clipboardPayload = (await cutSelection(remdo)) as { nodes: SerializedLexicalNode[] };
+    const note1 = findSerializedListItem(clipboardPayload.nodes[0]!, 'note1')!;
+    const note2 = findSerializedListItem(clipboardPayload.nodes[0]!, 'note2')!;
+    note2.noteId = note1.noteId;
+
+    await pastePayload(remdo, clipboardPayload);
+
+    const outline = readOutline(remdo);
+    const restoredNote1 = findOutlineNodeByText(outline, 'note1')!;
+    const restoredNote2 = findOutlineNodeByText(outline, 'note2')!;
+    expect(restoredNote1.noteId).not.toBe('note1');
+    expect(restoredNote2.noteId).not.toBe('note1');
+    const noteIds = collectOutlineNoteIds(outline);
+    expect(new Set(noteIds).size).toBe(noteIds.length);
+  });
+
+  it('regenerates the whole cut set when one incoming id collides', meta({ fixture: 'flat' }), async ({ remdo }) => {
+    await selectStructuralNotes(remdo, 'note1', 'note2');
+    const clipboardPayload = await cutSelection(remdo);
+
+    await remdo.mutate(() => {
+      const collision = $createListItemNode();
+      collision.append($createTextNode('collision'));
+      $setState(collision, noteIdState, 'note1');
+      $findNoteById('note3')!.insertAfter(collision);
+    });
+    await placeCaretAtNote(remdo, 'note3', Number.POSITIVE_INFINITY);
+    await pastePayload(remdo, clipboardPayload);
+
+    const outline = readOutline(remdo);
+    const restoredNote1 = findOutlineNodeByText(outline, 'note1')!;
+    const restoredNote2 = findOutlineNodeByText(outline, 'note2')!;
+    expect(restoredNote1.noteId).not.toBe('note1');
+    expect(restoredNote2.noteId).not.toBe('note2');
+    const noteIds = collectOutlineNoteIds(outline);
+    expect(new Set(noteIds).size).toBe(noteIds.length);
+  });
+
+  it('preserves ids on the first same-document cut paste and regenerates them on repeat', meta({ fixture: 'flat' }), async ({ remdo }) => {
+    await selectStructuralNotes(remdo, 'note2');
+    const clipboardPayload = await cutSelection(remdo);
+    expect((clipboardPayload as { remdo?: { sourceDocumentId?: string } }).remdo).toEqual(
+      expect.objectContaining({ sourceDocumentId: remdo.getCollabDocId() })
+    );
+    expect(findSerializedListItem((clipboardPayload.nodes as SerializedLexicalNode[])[0]!, 'note2')).not.toBeNull();
+
+    expect(remdo).toMatchOutline([
+      { noteId: 'note1', text: 'note1' },
+      { noteId: 'note3', text: 'note3' },
+    ]);
+
+    await placeCaretAtNote(remdo, 'note3', Number.POSITIVE_INFINITY);
+    await pastePayload(remdo, clipboardPayload);
+    await pastePayload(remdo, clipboardPayload);
+
+    expect(remdo).toMatchOutline([
+      { noteId: 'note1', text: 'note1' },
+      { noteId: 'note3', text: 'note3' },
+      { noteId: 'note2', text: 'note2' },
+      { noteId: null, text: 'note2' },
+    ]);
+
+    const outline = readOutline(remdo);
+    const firstPasteId = outline[2]?.noteId;
+    const repeatedPasteId = outline[3]?.noteId;
+    expect(firstPasteId).toBe('note2');
+    expect(repeatedPasteId).toEqual(expect.any(String));
+    expect(repeatedPasteId).not.toBe('note2');
+    const noteIds = collectOutlineNoteIds(outline);
+    expect(new Set(noteIds).size).toBe(noteIds.length);
   });
 });

--- a/src/client/editor/editing/clipboard/clipboard-note-ids.spec.ts
+++ b/src/client/editor/editing/clipboard/clipboard-note-ids.spec.ts
@@ -620,6 +620,21 @@ describe('note ids on paste', () => {
     expect(remdo).toMatchEditorState(initialState);
   });
 
+  it('round-trips after leaving and returning to the deletion caret', meta({ fixture: 'tree-complex' }), async ({ remdo }) => {
+    await remdo.waitForSynced();
+    const initialState = remdo.getEditorState();
+
+    await selectStructuralNotes(remdo, 'note4');
+    const clipboardPayload = await cutSelection(remdo);
+
+    await placeCaretAtNote(remdo, 'note5', Number.POSITIVE_INFINITY);
+    await placeCaretAtNote(remdo, 'note3', Number.POSITIVE_INFINITY);
+    await pastePayload(remdo, clipboardPayload);
+    await remdo.waitForSynced();
+
+    expect(remdo).toMatchEditorState(initialState);
+  });
+
   it('round-trips formatted note content exactly', meta({ fixture: 'formatted' }), async ({ remdo }) => {
     const initialState = remdo.getEditorState();
 

--- a/src/client/editor/outline/selection/delete-selection.ts
+++ b/src/client/editor/outline/selection/delete-selection.ts
@@ -10,6 +10,7 @@ import {
 } from 'lexical';
 import { $resolveViewRoot } from '#client/editor/outline/view-root';
 import { $normalizeOutlineRoot } from '#client/editor/outline/normalization';
+import type { OutlineSelectionRange } from '#client/editor/outline/selection/model';
 import {
   $requireRootContentList,
   $resolveRootContentList,
@@ -30,7 +31,7 @@ interface ResolvedDeletion {
 // the caret placement needs. Null when nothing is deletable. Non-mutating.
 function $resolveDeletionForRange(
   editor: LexicalEditor,
-  range: ReturnType<typeof $resolveSelectedNoteRange>
+  range: OutlineSelectionRange | null
 ): ResolvedDeletion | null {
   if (!range) {
     return null;
@@ -64,6 +65,15 @@ function $resolveSelectedNotesDeletion(editor: LexicalEditor): ResolvedDeletion 
  */
 export function $deleteSelectedNotes(editor: LexicalEditor): boolean {
   return $applyResolvedDeletion($resolveStructuralDeletion(editor));
+}
+
+/**
+ * Delete a resolved note range and apply the structural deletion focus order.
+ * Clipboard cut uses the same semantic deletion as Backspace/Delete even
+ * when the native Lexical range only partially covers a note representation.
+ */
+export function $deleteNotesInRange(editor: LexicalEditor, range: OutlineSelectionRange): boolean {
+  return $applyResolvedDeletion($resolveDeletionForRange(editor, range));
 }
 
 /**

--- a/src/client/editor/outline/selection/range.ts
+++ b/src/client/editor/outline/selection/range.ts
@@ -43,7 +43,3 @@ export function $resolveStructuralItemsFromRange(range: OutlineSelectionRange): 
   }
   return items;
 }
-
-export function $collectStructuralItemKeysFromRange(range: OutlineSelectionRange): Set<string> {
-  return new Set($resolveStructuralItemsFromRange(range).map((item) => item.getKey()));
-}

--- a/src/client/editor/shell/Editor.css
+++ b/src/client/editor/shell/Editor.css
@@ -93,7 +93,6 @@
 .editor-input {
   --remdo-structural-highlight-inset: var(--mantine-spacing-sm);
   --remdo-selection-color: rgba(97, 140, 255, 0.35);
-  --remdo-cut-marker-color: var(--mantine-color-dark-3);
   outline: none;
   white-space: pre-wrap;
   word-break: normal;
@@ -125,25 +124,6 @@
   opacity: 1;
   top: var(--structural-selection-top, 0px);
   height: var(--structural-selection-height, 0px);
-}
-
-.editor-input::after {
-  content: '';
-  position: absolute;
-  left: calc(0px - var(--remdo-structural-highlight-inset));
-  right: calc(0px - var(--remdo-structural-highlight-inset));
-  border-radius: var(--mantine-radius-sm);
-  border: 1px dashed var(--remdo-cut-marker-color);
-  pointer-events: none;
-  opacity: 0;
-  top: 0;
-  height: 0;
-}
-
-.editor-input.editor-input--cut-marker::after {
-  opacity: 1;
-  top: var(--cut-marker-top, 0px);
-  height: var(--cut-marker-height, 0px);
 }
 
 .editor-input.editor-input--structural::selection,

--- a/tests/e2e/_support/fixtures.ts
+++ b/tests/e2e/_support/fixtures.ts
@@ -9,10 +9,6 @@ interface EditorLike {
   getEditorState: () => Promise<unknown>;
 }
 
-export async function readOutline(editor: EditorLike): Promise<Outline> {
-  return extractOutlineFromEditorState(await editor.getEditorState());
-}
-
 interface ConsoleIssueMatchers {
   exactCounts: Map<string, number>;
   containsCounts: Map<string, number>;

--- a/tests/e2e/editor/_support/fixtures.ts
+++ b/tests/e2e/editor/_support/fixtures.ts
@@ -1,4 +1,4 @@
-import { expect, readOutline, test as base } from '#e2e/fixtures';
+import { expect, test as base } from '#e2e/fixtures';
 import type { Locator, Page } from '#e2e/fixtures';
 import type { BrowserContext } from '@playwright/test';
 import { createUniqueNoteId } from '#domain/notes/ids';
@@ -39,5 +39,5 @@ export const test = base.extend<
   },
 });
 
-export { expect, readOutline };
+export { expect };
 export type { Page, Locator };

--- a/tests/e2e/editor/selection.spec.ts
+++ b/tests/e2e/editor/selection.spec.ts
@@ -1,5 +1,4 @@
-import type { Locator } from '#editor/fixtures';
-import { expect, readOutline, test } from '#editor/fixtures';
+import { expect, test } from '#editor/fixtures';
 import { editorLocator, selectInlineRange, setCaretAtNoteTextNode, setCaretAtText } from '#editor/locators';
 
 test.describe('selection (structural highlight)', () => {
@@ -21,35 +20,8 @@ test.describe('selection (structural highlight)', () => {
   });
 });
 
-test.describe('selection (cut marker)', () => {
-  test('replaces the structural highlight with the cut marker overlay', async ({ page, editor }) => {
-    await editor.load('flat');
-    await setCaretAtText(page, 'note2');
-
-    const input = editorLocator(page).locator('.editor-input').first();
-    await expect(input).not.toHaveClass(/editor-input--structural/);
-
-    await page.keyboard.press('Shift+ArrowDown');
-    await page.keyboard.press('Shift+ArrowDown');
-
-    await expect(input).toHaveClass(/editor-input--structural/);
-
-    const selectionVars = await readOverlayVars(input, '--structural-selection-top', '--structural-selection-height');
-    expect(Number.parseFloat(selectionVars.height)).toBeGreaterThan(0);
-
-    const cutCombo = process.platform === 'darwin' ? 'Meta+X' : 'Control+X';
-    await page.keyboard.press(cutCombo);
-
-    await expect(input).not.toHaveClass(/editor-input--structural/);
-    await expect(input).toHaveClass(/editor-input--cut-marker/);
-
-    const cutVars = await readOverlayVars(input, '--cut-marker-top', '--cut-marker-height');
-    expect(Number.parseFloat(cutVars.height)).toBeGreaterThan(0);
-    expect(cutVars.top).toBe(selectionVars.top);
-    expect(cutVars.height).toBe(selectionVars.height);
-  });
-
-  test('moves a note range on cut and paste', async ({ page, editor }) => {
+test.describe('clipboard (structural cut)', () => {
+  test('removes a note range immediately and pastes it elsewhere', async ({ page, editor }) => {
     await editor.load('flat');
     await setCaretAtText(page, 'note1');
 
@@ -61,7 +33,10 @@ test.describe('selection (cut marker)', () => {
     const cutCombo = process.platform === 'darwin' ? 'Meta+X' : 'Control+X';
     await page.keyboard.press(cutCombo);
 
-    await expect(input).toHaveClass(/editor-input--cut-marker/);
+    await expect(editor).toMatchOutline([
+      { noteId: 'note2', text: 'note2' },
+      { noteId: 'note3', text: 'note3' },
+    ]);
 
     await setCaretAtText(page, 'note3', Number.POSITIVE_INFINITY);
     const pasteCombo = process.platform === 'darwin' ? 'Meta+V' : 'Control+V';
@@ -72,77 +47,7 @@ test.describe('selection (cut marker)', () => {
       { noteId: 'note3', text: 'note3' },
       { noteId: 'note1', text: 'note1' },
     ]);
-    await expect(input).not.toHaveClass(/editor-input--cut-marker/);
     await expect(input).not.toHaveClass(/editor-input--structural/);
-  });
-
-  test('keeps the cut marker when pasting inside the marked subtree', async ({ page, editor }) => {
-    await editor.load('flat');
-    await setCaretAtText(page, 'note2');
-
-    const input = editorLocator(page).locator('.editor-input').first();
-
-    await page.keyboard.press('Shift+ArrowDown');
-    await page.keyboard.press('Shift+ArrowDown');
-
-    const cutCombo = process.platform === 'darwin' ? 'Meta+X' : 'Control+X';
-    await page.keyboard.press(cutCombo);
-
-    await expect(input).toHaveClass(/editor-input--cut-marker/);
-
-    const expectedOutline = await readOutline(editor);
-
-    const pasteCombo = process.platform === 'darwin' ? 'Meta+V' : 'Control+V';
-    await page.keyboard.press(pasteCombo);
-
-    await expect(editor).toMatchOutline(expectedOutline);
-    await expect(input).toHaveClass(/editor-input--cut-marker/);
-  });
-
-  test('clears the cut marker after pasting a non-cut payload', async ({ page, editor }) => {
-    await editor.load('flat');
-    await setCaretAtText(page, 'note2');
-
-    const input = editorLocator(page).locator('.editor-input').first();
-
-    await page.keyboard.press('Shift+ArrowDown');
-    await page.keyboard.press('Shift+ArrowDown');
-
-    const cutCombo = process.platform === 'darwin' ? 'Meta+X' : 'Control+X';
-    await page.keyboard.press(cutCombo);
-
-    await expect(input).toHaveClass(/editor-input--cut-marker/);
-
-    await setCaretAtText(page, 'note3');
-    await input.evaluate((element) => {
-      const data = new DataTransfer();
-      data.setData('text/plain', 'paste');
-      const event = new ClipboardEvent('paste', { clipboardData: data, bubbles: true, cancelable: true });
-      element.dispatchEvent(event);
-    });
-
-    await expect(input).not.toHaveClass(/editor-input--cut-marker/);
-  });
-
-  test('clears the cut marker after pasting moved notes', async ({ page, editor }) => {
-    await editor.load('flat');
-    await setCaretAtText(page, 'note2');
-
-    const input = editorLocator(page).locator('.editor-input').first();
-
-    await page.keyboard.press('Shift+ArrowDown');
-    await page.keyboard.press('Shift+ArrowDown');
-
-    const cutCombo = process.platform === 'darwin' ? 'Meta+X' : 'Control+X';
-    await page.keyboard.press(cutCombo);
-
-    await expect(input).toHaveClass(/editor-input--cut-marker/);
-
-    await setCaretAtText(page, 'note3', Number.POSITIVE_INFINITY);
-    const pasteCombo = process.platform === 'darwin' ? 'Meta+V' : 'Control+V';
-    await page.keyboard.press(pasteCombo);
-
-    await expect(input).not.toHaveClass(/editor-input--cut-marker/);
   });
 });
 
@@ -208,19 +113,6 @@ test.describe('clipboard (caret paste placement)', () => {
     ]);
   });
 });
-
-async function readOverlayVars(input: Locator, topVar: string, heightVar: string) {
-  return input.evaluate(
-    (element, vars) => {
-      const style = getComputedStyle(element);
-      return {
-        top: style.getPropertyValue(vars.topVar).trim(),
-        height: style.getPropertyValue(vars.heightVar).trim(),
-      };
-    },
-    { topVar, heightVar }
-  );
-}
 
 async function pastePlainText(page: Parameters<typeof editorLocator>[0], text: string) {
   const input = editorLocator(page).locator('.editor-input').first();

--- a/tests/unit/_support/lib/clipboard.ts
+++ b/tests/unit/_support/lib/clipboard.ts
@@ -77,11 +77,8 @@ function readClipboardPayload(clipboardEvent: ClipboardEvent, label: string) {
   return JSON.parse(rawPayload) as { namespace?: string; nodes?: unknown[] };
 }
 
-// CUT_COMMAND only marks a note range for move; this helper reads
-// the payload the cut handler writes to the clipboard so paste stays realistic.
-// Limitation: structural cut collapses the selection onto the cut note; in
-// collab tests, relocate the caret before a remote delete of that note to
-// avoid Lexical/Yjs "node does not exist" errors.
+// Reads the payload populated before CUT_COMMAND removes a structural range so
+// paste tests exercise the same serialized boundary as the browser clipboard.
 export async function cutSelection(remdo: RemdoTestApi) {
   const clipboardEvent = createClipboardEvent(undefined, 'cut');
   await remdo.dispatchCommand(CUT_COMMAND, clipboardEvent, { expect: 'update' });

--- a/tests/unit/_support/lib/dom-selection.ts
+++ b/tests/unit/_support/lib/dom-selection.ts
@@ -2,6 +2,7 @@ import { act, waitFor } from '@testing-library/react';
 import { expect } from 'vitest';
 
 import type { RemdoTestApi } from '#client/editor/dev';
+import { flattenOutline } from '#tests-common/outline';
 import { readOutline, placeCaretAtNote, selectNoteRange } from './note';
 import { pressKey } from './keyboard';
 import { getNoteElement } from './dom-note';
@@ -73,7 +74,7 @@ export async function selectStructuralNotes(
   endNoteId: string = startNoteId
 ): Promise<void> {
   if (startNoteId === endNoteId) {
-    const noteText = readOutline(remdo).find((note) => note.noteId === startNoteId)?.text ?? '';
+    const noteText = flattenOutline(readOutline(remdo)).find((note) => note.noteId === startNoteId)?.text ?? '';
     const needsInlineStage = noteText.trim().length > 0;
     await placeCaretAtNote(remdo, startNoteId, 0);
 

--- a/tests/unit/_support/lib/keyboard.ts
+++ b/tests/unit/_support/lib/keyboard.ts
@@ -94,7 +94,6 @@ export async function pressKey(
 /**
  * Inserts plain text characters using Lexical's controlled insertion path.
  * If the keydown is prevented by the editor (e.g., structural mode), no text is inserted.
- * For deterministic model-only edits, prefer {@link appendTextToNote} in note helpers.
  */
 export async function typeText(remdo: RemdoTestApi, text: string): Promise<void> {
   const root = getRootElementOrThrow(remdo.editor);

--- a/tests/unit/_support/lib/note.ts
+++ b/tests/unit/_support/lib/note.ts
@@ -5,7 +5,6 @@ import { waitFor } from '@testing-library/react';
 import type { TextNode } from 'lexical';
 import {
   $createRangeSelection,
-  $createTextNode,
   $getNodeByKey,
   $getRoot,
   $getSelection,
@@ -142,25 +141,6 @@ export async function placeCaretAtNoteTextNode(
   await waitFor(() => {
     expect(readCaretNoteId(remdo)).toBe(noteId);
     expect(remdo.editor.selection.get()?.kind).toBe('caret');
-  });
-}
-
-/**
- * Appends text to the note with the given id without going through input events.
- * Use for deterministic model-only edits (e.g., remote collab changes).
- * For user-typing behavior, prefer {@link typeText} from keyboard helpers.
- */
-export async function appendTextToNote(remdo: RemdoTestApi, noteId: string, text: string) {
-  await remdo.mutate(() => {
-    const item = $findItemByNoteId(noteId);
-
-    const textNode = item.getChildren().find((child): child is TextNode => child.getType() === 'text');
-    if (textNode) {
-      textNode.setTextContent(`${textNode.getTextContent()}${text}`);
-      return;
-    }
-
-    item.append($createTextNode(text));
   });
 }
 

--- a/tests/unit/collab/note-ids.collab.spec.tsx
+++ b/tests/unit/collab/note-ids.collab.spec.tsx
@@ -1,7 +1,8 @@
 import { waitFor } from '@testing-library/react';
+import { $createListItemNode } from '@lexical/list';
 import { describe, expect, it } from 'vitest';
+import { $createTextNode, $setState } from 'lexical';
 import {
-  appendTextToNote,
   copySelection,
   cutSelection,
   pastePayload,
@@ -9,8 +10,11 @@ import {
   pressKey,
   readOutline,
   selectStructuralNotes,
+  typeText,
   meta,
 } from '#tests';
+import { $findNoteById } from '#client/editor/outline/note-traversal';
+import { noteIdState } from '#client/editor/runtime/note-ids/note-id-state';
 import { createCollabPeer } from './_support/remdo-peers';
 import { COLLAB_LONG_TIMEOUT_MS } from './_support/timeouts';
 
@@ -169,18 +173,27 @@ describe('collaboration note ids', { timeout: COLLAB_LONG_TIMEOUT_MS }, () => {
     });
   });
 
-  it('drops cut markers after remote edits', meta({ fixture: 'flat' }), async ({ remdo }) => {
+  it('syncs immediate structural cut removal and the later same-document paste', meta({ fixture: 'flat' }), async ({ remdo }) => {
     const secondary = await createCollabPeer(remdo);
 
     await selectStructuralNotes(remdo, 'note2');
     const clipboardPayload = await cutSelection(remdo);
 
-    await placeCaretAtNote(secondary, 'note2', Number.POSITIVE_INFINITY);
-    await appendTextToNote(secondary, 'note2', ' remote');
+    const afterCut = [
+      { noteId: 'note1', text: 'note1' },
+      { noteId: 'note3', text: 'note3' },
+    ];
+    expect(remdo).toMatchOutline(afterCut);
+
+    await waitFor(() => {
+      expect(secondary).toMatchOutline(afterCut);
+    });
+
+    await placeCaretAtNote(secondary, 'note1', Number.POSITIVE_INFINITY);
+    await typeText(secondary, ' remote');
     await waitFor(() => {
       expect(remdo).toMatchOutline([
-        { noteId: 'note1', text: 'note1' },
-        { noteId: 'note2', text: 'note2 remote' },
+        { noteId: 'note1', text: 'note1 remote' },
         { noteId: 'note3', text: 'note3' },
       ]);
     });
@@ -188,192 +201,53 @@ describe('collaboration note ids', { timeout: COLLAB_LONG_TIMEOUT_MS }, () => {
     await placeCaretAtNote(remdo, 'note3', Number.POSITIVE_INFINITY);
     await pastePayload(remdo, clipboardPayload);
 
-    // Paste is a no-op because the cut marker was invalidated by the remote edit.
     const expectedOutline = [
-      { noteId: 'note1', text: 'note1' },
-      { noteId: 'note2', text: 'note2 remote' },
+      { noteId: 'note1', text: 'note1 remote' },
       { noteId: 'note3', text: 'note3' },
-    ];
-    expect(remdo).toMatchOutline(expectedOutline);
-    await waitFor(() => {
-      expect(secondary).toMatchOutline(expectedOutline);
-    });
-  });
-
-  it('drops cut markers after remote deletions', meta({ fixture: 'flat' }), async ({ remdo }) => {
-    const secondary = await createCollabPeer(remdo);
-
-    await selectStructuralNotes(remdo, 'note2');
-    const clipboardPayload = await cutSelection(remdo);
-    await placeCaretAtNote(remdo, 'note1', Number.POSITIVE_INFINITY);
-
-    await selectStructuralNotes(secondary, 'note2');
-    await pressKey(secondary, { key: 'Delete' });
-
-    const expectedOutline = [
-      { noteId: 'note1', text: 'note1' },
-      { noteId: 'note3', text: 'note3' },
+      { noteId: 'note2', text: 'note2' },
     ];
 
     await waitFor(() => {
       expect(remdo).toMatchOutline(expectedOutline);
-    });
-
-    await placeCaretAtNote(remdo, 'note3', Number.POSITIVE_INFINITY);
-    await pastePayload(remdo, clipboardPayload);
-
-    expect(remdo).toMatchOutline(expectedOutline);
-    await waitFor(() => {
       expect(secondary).toMatchOutline(expectedOutline);
     });
   });
 
-  it('keeps structural cut-paste as no-op after remote deletion of the cut source', meta({ fixture: 'flat' }), async ({ remdo }) => {
+  it('regenerates a cut id that a peer reintroduces before paste', meta({ fixture: 'flat' }), async ({ remdo }) => {
     const secondary = await createCollabPeer(remdo);
 
     await selectStructuralNotes(remdo, 'note2');
     const clipboardPayload = await cutSelection(remdo);
-    await placeCaretAtNote(remdo, 'note1', Number.POSITIVE_INFINITY);
-
-    await selectStructuralNotes(secondary, 'note2');
-    await pressKey(secondary, { key: 'Delete' });
-
-    const expectedOutline = [
-      { noteId: 'note1', text: 'note1' },
-      { noteId: 'note3', text: 'note3' },
-    ];
-
     await waitFor(() => {
-      expect(remdo).toMatchOutline(expectedOutline);
+      expect(secondary).toMatchOutline(readOutline(remdo));
     });
 
-    // Single-note structural destination makes fallback-to-destination behavior
-    // obvious: if fallback runs, note1 would be moved/removed.
-    await selectStructuralNotes(remdo, 'note1');
-    await pastePayload(remdo, clipboardPayload);
-
-    expect(remdo).toMatchOutline(expectedOutline);
-    await waitFor(() => {
-      expect(secondary).toMatchOutline(expectedOutline);
+    await secondary.mutate(() => {
+      const collision = $createListItemNode();
+      collision.append($createTextNode('collision'));
+      $setState(collision, noteIdState, 'note2');
+      $findNoteById('note3')!.insertAfter(collision);
     });
-  });
-
-  it('drops cut markers after remote structural edits', meta({ fixture: 'flat' }), async ({ remdo }) => {
-    const secondary = await createCollabPeer(remdo);
-
-    await selectStructuralNotes(remdo, 'note2');
-    const clipboardPayload = await cutSelection(remdo);
-
-    await placeCaretAtNote(secondary, 'note2', 0);
-    await pressKey(secondary, { key: 'Tab' });
-
-    const expectedOutline = [
-      { noteId: 'note1', text: 'note1', children: [{ noteId: 'note2', text: 'note2' }] },
-      { noteId: 'note3', text: 'note3' },
-    ];
-    await waitFor(() => {
-      expect(remdo).toMatchOutline(expectedOutline);
-    });
-
-    await placeCaretAtNote(remdo, 'note3', Number.POSITIVE_INFINITY);
-    await pastePayload(remdo, clipboardPayload);
-
-    expect(remdo).toMatchOutline(expectedOutline);
-    await waitFor(() => {
-      expect(secondary).toMatchOutline(expectedOutline);
-    });
-  });
-
-  it('drops cut markers after remote inserts inside the cut boundary', meta({ fixture: 'flat' }), async ({ remdo }) => {
-    const secondary = await createCollabPeer(remdo);
-
-    await selectStructuralNotes(remdo, 'note2', 'note3');
-    const clipboardPayload = await cutSelection(remdo);
-
-    await placeCaretAtNote(secondary, 'note2', Number.POSITIVE_INFINITY);
-    await pressKey(secondary, { key: 'Enter' });
     await waitFor(() => {
       expect(remdo).toMatchOutline(readOutline(secondary));
     });
 
-    const expectedOutline = readOutline(remdo);
-
-    await placeCaretAtNote(remdo, 'note1', 0);
-    await pastePayload(remdo, clipboardPayload);
-
-    expect(remdo).toMatchOutline(expectedOutline);
-    await waitFor(() => {
-      expect(secondary).toMatchOutline(expectedOutline);
-    });
-  });
-
-  it('merges cut moves with concurrent edits on the moved note', meta({ fixture: 'flat' }, { retry: 3 }), async ({ remdo }) => {
-    const secondary = await createCollabPeer(remdo);
-
-    await selectStructuralNotes(remdo, 'note2');
-    const clipboardPayload = await cutSelection(remdo);
-
     await placeCaretAtNote(remdo, 'note3', Number.POSITIVE_INFINITY);
     await pastePayload(remdo, clipboardPayload);
 
-    await placeCaretAtNote(secondary, 'note2', Number.POSITIVE_INFINITY);
-    await appendTextToNote(secondary, 'note2', ' remote');
-
-    const expectedOutline = [
-      { noteId: 'note1', text: 'note1' },
-      { noteId: 'note3', text: 'note3' },
-      { noteId: 'note2', text: 'note2 remote' },
-    ];
-
     await waitFor(() => {
-      expect(remdo).toMatchOutline(expectedOutline);
-      expect(secondary).toMatchOutline(expectedOutline);
-    });
-  });
+      const outline = readOutline(remdo);
+      const original = outline.find((note) => note.text === 'note2')!;
+      const collision = outline.find((note) => note.text === 'collision')!;
+      const noteIds = outline
+        .map((note) => note.noteId)
+        .filter((noteId): noteId is string => typeof noteId === 'string');
 
-  it('merges cut moves with concurrent edits on a moved subtree', meta({ fixture: 'tree-complex' }, { retry: 3 }), async ({ remdo }) => {
-    expect(remdo).toMatchOutline([
-      {
-        noteId: 'note1',
-        text: 'note1',
-        children: [
-          { noteId: 'note2', text: 'note2', children: [{ noteId: 'note3', text: 'note3' }] },
-          { noteId: 'note4', text: 'note4' },
-        ],
-      },
-      { noteId: 'note5', text: 'note5' },
-      { noteId: 'note6', text: 'note6', children: [{ noteId: 'note7', text: 'note7' }] },
-    ]);
-
-    const secondary = await createCollabPeer(remdo);
-
-    await selectStructuralNotes(remdo, 'note6', 'note7');
-    expect(remdo).toMatchSelection({ state: 'structural', notes: ['note6', 'note7'] });
-
-    const clipboardPayload = await cutSelection(remdo);
-
-    await placeCaretAtNote(remdo, 'note1', Number.POSITIVE_INFINITY);
-    await pastePayload(remdo, clipboardPayload);
-
-    await placeCaretAtNote(secondary, 'note7', Number.POSITIVE_INFINITY);
-    await appendTextToNote(secondary, 'note7', ' remote');
-
-    const expectedOutline = [
-      {
-        noteId: 'note1',
-        text: 'note1',
-        children: [
-          { noteId: 'note6', text: 'note6', children: [{ noteId: 'note7', text: 'note7 remote' }] },
-          { noteId: 'note2', text: 'note2', children: [{ noteId: 'note3', text: 'note3' }] },
-          { noteId: 'note4', text: 'note4' },
-        ],
-      },
-      { noteId: 'note5', text: 'note5' },
-    ];
-
-    await waitFor(() => {
-      expect(remdo).toMatchOutline(expectedOutline);
-      expect(secondary).toMatchOutline(expectedOutline);
+      expect(original.noteId).toEqual(expect.any(String));
+      expect(original.noteId).not.toBe('note2');
+      expect(collision.noteId).toBe('note2');
+      expect(new Set(noteIds).size).toBe(noteIds.length);
+      expect(secondary).toMatchOutline(outline);
     });
   });
 });


### PR DESCRIPTION
…pdate provenance-based cut payloads, drop cut marker overlays, preserve first same-document ids and validate body paste as inline label content